### PR TITLE
Refactor: use dataclasses and enumerated unit types

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -36,3 +36,4 @@ Some of the significant design decisions made within this library are:
 * Empty time segments at the end of duration strings are allowed (``P1DT`` is considered valid)
 * Measurement limits are checked within date/time segments (``PT20:59:01`` is within limits; ``PT20:60:01`` is not)
 * Measurement values are parsed into floating-point values (at the time of writing, precise procedural algorithms to parse base-ten strings into integers for large inputs are not practical -- or not widely known)
+* When inputs are reliably known to be of correct type and format, assertions should be safe to remove (for example, by including the [`-O` command-line flag when invoking the Python interpreter](https://docs.python.org/3/using/cmdline.html#cmdoption-O)) to improve runtime performance

--- a/README.rst
+++ b/README.rst
@@ -36,4 +36,4 @@ Some of the significant design decisions made within this library are:
 * Empty time segments at the end of duration strings are allowed (``P1DT`` is considered valid)
 * Measurement limits are checked within date/time segments (``PT20:59:01`` is within limits; ``PT20:60:01`` is not)
 * Measurement values are parsed into floating-point values (at the time of writing, precise procedural algorithms to parse base-ten strings into integers for large inputs are not practical -- or not widely known)
-* When inputs are reliably known to be of correct type and format, assertions should be safe to remove (for example, by including the `-O command-line flag when invoking the Python interpreter <https://docs.python.org/3/using/cmdline.html#cmdoption-O>)`_) to improve runtime performance
+* When inputs are reliably known to be of correct type and format, assertions should be safe to remove (for example, by including the `-O command-line flag when invoking the Python interpreter <https://docs.python.org/3/using/cmdline.html#cmdoption-O>`_) to improve runtime performance

--- a/README.rst
+++ b/README.rst
@@ -36,4 +36,4 @@ Some of the significant design decisions made within this library are:
 * Empty time segments at the end of duration strings are allowed (``P1DT`` is considered valid)
 * Measurement limits are checked within date/time segments (``PT20:59:01`` is within limits; ``PT20:60:01`` is not)
 * Measurement values are parsed into floating-point values (at the time of writing, precise procedural algorithms to parse base-ten strings into integers for large inputs are not practical -- or not widely known)
-* When inputs are reliably known to be of correct type and format, assertions should be safe to remove (for example, by including the `-O command-line flag when invoking the Python interpreter <https://docs.python.org/3/using/cmdline.html#cmdoption-O)`_) to improve runtime performance
+* When inputs are reliably known to be of correct type and format, assertions should be safe to remove (for example, by including the `-O command-line flag when invoking the Python interpreter <https://docs.python.org/3/using/cmdline.html#cmdoption-O>)`_) to improve runtime performance

--- a/README.rst
+++ b/README.rst
@@ -36,4 +36,4 @@ Some of the significant design decisions made within this library are:
 * Empty time segments at the end of duration strings are allowed (``P1DT`` is considered valid)
 * Measurement limits are checked within date/time segments (``PT20:59:01`` is within limits; ``PT20:60:01`` is not)
 * Measurement values are parsed into floating-point values (at the time of writing, precise procedural algorithms to parse base-ten strings into integers for large inputs are not practical -- or not widely known)
-* When inputs are reliably known to be of correct type and format, assertions should be safe to remove (for example, by including the `-O command-line flag when invoking the Python interpreter <https://docs.python.org/3/using/cmdline.html#cmdoption-O>`_) to improve runtime performance
+* When inputs are reliably known to be of correct type and format, assertions should be safe to remove (for example, by including the `-O command-line flag when invoking the Python interpreter <https://docs.python.org/3/using/cmdline.html#cmdoption-O>)`_) to improve runtime performance

--- a/README.rst
+++ b/README.rst
@@ -36,4 +36,4 @@ Some of the significant design decisions made within this library are:
 * Empty time segments at the end of duration strings are allowed (``P1DT`` is considered valid)
 * Measurement limits are checked within date/time segments (``PT20:59:01`` is within limits; ``PT20:60:01`` is not)
 * Measurement values are parsed into floating-point values (at the time of writing, precise procedural algorithms to parse base-ten strings into integers for large inputs are not practical -- or not widely known)
-* When inputs are reliably known to be of correct type and format, assertions should be safe to remove (for example, by including the `-O command-line flag when invoking the Python interpreter <https://docs.python.org/3/using/cmdline.html#cmdoption-O)`_) to improve runtime performance
+* When inputs are reliably known to be of correct type and format, assertions should be safe to remove (for example, by including the [`-O` command-line flag when invoking the Python interpreter](https://docs.python.org/3/using/cmdline.html#cmdoption-O)) to improve runtime performance

--- a/README.rst
+++ b/README.rst
@@ -36,4 +36,4 @@ Some of the significant design decisions made within this library are:
 * Empty time segments at the end of duration strings are allowed (``P1DT`` is considered valid)
 * Measurement limits are checked within date/time segments (``PT20:59:01`` is within limits; ``PT20:60:01`` is not)
 * Measurement values are parsed into floating-point values (at the time of writing, precise procedural algorithms to parse base-ten strings into integers for large inputs are not practical -- or not widely known)
-* When inputs are reliably known to be of correct type and format, assertions should be safe to remove (for example, by including the [`-O` command-line flag when invoking the Python interpreter](https://docs.python.org/3/using/cmdline.html#cmdoption-O)) to improve runtime performance
+* When inputs are reliably known to be of correct type and format, assertions should be safe to remove (for example, by including the `-O command-line flag when invoking the Python interpreter <https://docs.python.org/3/using/cmdline.html#cmdoption-O)`_) to improve runtime performance

--- a/README.rst
+++ b/README.rst
@@ -36,4 +36,4 @@ Some of the significant design decisions made within this library are:
 * Empty time segments at the end of duration strings are allowed (``P1DT`` is considered valid)
 * Measurement limits are checked within date/time segments (``PT20:59:01`` is within limits; ``PT20:60:01`` is not)
 * Measurement values are parsed into floating-point values (at the time of writing, precise procedural algorithms to parse base-ten strings into integers for large inputs are not practical -- or not widely known)
-* When inputs are reliably known to be of correct type and format, assertions should be safe to remove (for example, by including the `-O command-line flag when invoking the Python interpreter <https://docs.python.org/3/using/cmdline.html#cmdoption-O>)`_) to improve runtime performance
+* When inputs are reliably known to be of correct type and format, assertions should be safe to remove (for example, by including the `-O command-line flag when invoking the Python interpreter <https://docs.python.org/3/using/cmdline.html#cmdoption-O)`_) to improve runtime performance

--- a/README.rst
+++ b/README.rst
@@ -36,4 +36,3 @@ Some of the significant design decisions made within this library are:
 * Empty time segments at the end of duration strings are allowed (``P1DT`` is considered valid)
 * Measurement limits are checked within date/time segments (``PT20:59:01`` is within limits; ``PT20:60:01`` is not)
 * Measurement values are parsed into floating-point values (at the time of writing, precise procedural algorithms to parse base-ten strings into integers for large inputs are not practical -- or not widely known)
-* When inputs are reliably known to be of correct type and format, assertions should be safe to remove (for example, by including the [`-O` command-line flag when invoking the Python interpreter](https://docs.python.org/3/using/cmdline.html#cmdoption-O)) to improve runtime performance

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ name = "timedelta-isoformat"
 readme = "README.rst"
 requires-python = ">= 3.10"
 urls = { Homepage = "https://pypi.org/project/timedelta-isoformat/", Source = "https://github.com/jayaddison/timedelta-isoformat.git/" }
-version = "0.6.2.2"
+version = "0.6.2.3"
 
 [tool.setuptools.package-data]
 "*" = ["py.typed"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ name = "timedelta-isoformat"
 readme = "README.rst"
 requires-python = ">= 3.10"
 urls = { Homepage = "https://pypi.org/project/timedelta-isoformat/", Source = "https://github.com/jayaddison/timedelta-isoformat.git/" }
-version = "0.6.2.4"
+version = "0.6.2.5"
 
 [tool.setuptools.package-data]
 "*" = ["py.typed"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ name = "timedelta-isoformat"
 readme = "README.rst"
 requires-python = ">= 3.10"
 urls = { Homepage = "https://pypi.org/project/timedelta-isoformat/", Source = "https://github.com/jayaddison/timedelta-isoformat.git/" }
-version = "0.6.2"
+version = "0.6.2.1"
 
 [tool.setuptools.package-data]
 "*" = ["py.typed"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ name = "timedelta-isoformat"
 readme = "README.rst"
 requires-python = ">= 3.10"
 urls = { Homepage = "https://pypi.org/project/timedelta-isoformat/", Source = "https://github.com/jayaddison/timedelta-isoformat.git/" }
-version = "0.6.1"
+version = "0.6.2"
 
 [tool.setuptools.package-data]
 "*" = ["py.typed"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ name = "timedelta-isoformat"
 readme = "README.rst"
 requires-python = ">= 3.10"
 urls = { Homepage = "https://pypi.org/project/timedelta-isoformat/", Source = "https://github.com/jayaddison/timedelta-isoformat.git/" }
-version = "0.6.2.3"
+version = "0.6.2.4"
 
 [tool.setuptools.package-data]
 "*" = ["py.typed"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ name = "timedelta-isoformat"
 readme = "README.rst"
 requires-python = ">= 3.10"
 urls = { Homepage = "https://pypi.org/project/timedelta-isoformat/", Source = "https://github.com/jayaddison/timedelta-isoformat.git/" }
-version = "0.6.2.1"
+version = "0.6.2.2"
 
 [tool.setuptools.package-data]
 "*" = ["py.typed"]

--- a/src/timedelta_isoformat/__init__.py
+++ b/src/timedelta_isoformat/__init__.py
@@ -18,7 +18,7 @@ class timedelta(datetime.timedelta):
         limit: int | None = None
         quantity: float = 0
 
-        def __post_init__(self):
+        def __post_init__(self) -> None:
             try:
                 assert self.value[0].isdigit()
                 self.quantity = float(self.value)
@@ -27,7 +27,7 @@ class timedelta(datetime.timedelta):
                 raise ValueError(msg) from exc
 
         @property
-        def valid(self):
+        def valid(self) -> bool:
             if not self.quantity: return False
             if not self.limit: return True
 

--- a/src/timedelta_isoformat/__init__.py
+++ b/src/timedelta_isoformat/__init__.py
@@ -76,7 +76,6 @@ class timedelta(datetime.timedelta):
         """
         time_tokens = iter(("Y", "years", "M", "months", "D", "days", "T", None, "H", "hours", "M", "minutes", "S", "seconds"))
         week_tokens = iter(("W", "weeks"))
-        contexts_encountered = set()
 
         tokens, value = time_tokens, ""
         for char in duration:
@@ -94,12 +93,13 @@ class timedelta(datetime.timedelta):
 
             unit = next(tokens)
             if unit:
-                contexts_encountered.add(tokens)
                 yield value, unit, None
             value = ""
 
-        assert contexts_encountered, "no measurements found"
-        assert len(contexts_encountered) == 1, "cannot mix weeks with other units"
+        weeks_parsed = next(week_tokens, None) != "W"
+        time_parsed = next(time_tokens, None) not in ("H", "Y")
+        assert weeks_parsed or time_parsed, "no measurements found"
+        assert weeks_parsed != time_parsed, "cannot mix weeks with other units"
 
     @classmethod
     def _from_duration(cls, duration: str) -> Measurements:

--- a/src/timedelta_isoformat/__init__.py
+++ b/src/timedelta_isoformat/__init__.py
@@ -29,7 +29,8 @@ class timedelta(datetime.timedelta):
 
         def _bounds_check(self) -> bool:
             if not self.limit:
-                return True
+                if 0 <= self.quantity:
+                    return True
 
             inclusive_limit = self.limit not in (24, 60)
             if inclusive_limit:

--- a/src/timedelta_isoformat/__init__.py
+++ b/src/timedelta_isoformat/__init__.py
@@ -10,7 +10,7 @@ class timedelta(datetime.timedelta):
     ISO8601-style parsing and formatting.
     """
 
-    Components: TypeAlias = Iterable[Tuple[str, str, int | None]]
+    Components: TypeAlias = Iterable[Tuple[str, str, int]]
     Measurements: TypeAlias = Iterable[Tuple[str, float]]
 
     def __repr__(self) -> str:
@@ -22,23 +22,23 @@ class timedelta(datetime.timedelta):
 
             # YYYY-DDD
             case _, _, _, _, "-", _, _, _:
-                yield segment[0:4], "years", None
+                yield segment[0:4], "years", 9999
                 yield segment[5:8], "days", 366
 
             # YYYY-MM-DD
             case _, _, _, _, "-", _, _, "-", _, _:
-                yield segment[0:4], "years", None
+                yield segment[0:4], "years", 9999
                 yield segment[5:7], "months", 12
                 yield segment[8:10], "days", 31
 
             # YYYYDDD
             case _, _, _, _, _, _, _:
-                yield segment[0:4], "years", None
+                yield segment[0:4], "years", 9999
                 yield segment[4:7], "days", 366
 
             # YYYYMMDD
             case _, _, _, _, _, _, _, _:
-                yield segment[0:4], "years", None
+                yield segment[0:4], "years", 9999
                 yield segment[4:6], "months", 12
                 yield segment[6:8], "days", 31
 

--- a/src/timedelta_isoformat/__init__.py
+++ b/src/timedelta_isoformat/__init__.py
@@ -21,17 +21,19 @@ class timedelta(datetime.timedelta):
         def __post_init__(self) -> None:
             assert self.value[0:1].isdigit(), f"unable to parse '{self.value}' as a positive decimal"
             self.quantity = float(self.value)
-            assert self._bounds_check()
+            try:
+                assert self._bounds_check()
+            except AssertionError as exc:
+                raise ValueError(f"{self.unit} value of {self.value} exceeds range {exc}")
 
         def _bounds_check(self) -> bool:
-            inclusive_limit = self.limit not in (24, 60)
-            match self.limit, inclusive_limit:
-                case None, _ if 0 <= self.quantity: return True
-                case _, True if 0 <= self.quantity <= self.limit: return True
-                case _, False if 0 <= self.quantity < self.limit: return True
-
-            bounds = f"[0..{self.limit}" + ("]" if inclusive_limit else ")")
-            raise ValueError(f"{self.unit} value of {self.value} exceeds range {bounds}")
+            if self.limit is None:
+                assert 0 <= self.quantity, "[0..+∞)"
+            elif self.limit in (24, 60):
+                assert 0 <= self.quantity < self.limit, f"[0..{self.limit})"
+            else:
+                assert 0 <= self.quantity <= self.limit, f"[0..{self.limit}]"
+            return True
 
     Components: TypeAlias = Iterable[Component]
 

--- a/src/timedelta_isoformat/__init__.py
+++ b/src/timedelta_isoformat/__init__.py
@@ -21,18 +21,16 @@ class timedelta(datetime.timedelta):
         def __post_init__(self) -> None:
             assert self.value[0:1].isdigit(), f"unable to parse '{self.value}' as a positive decimal"
             self.quantity = float(self.value)
-            try:
-                assert self._bounds_check()
-            except AssertionError as exc:
-                raise ValueError(f"{self.unit} value of {self.value} exceeds range {exc}")
+            assert self._bounds_check()
 
         def _bounds_check(self) -> bool:
+            msg = f"{self.unit} value of {self.value} exceeds range "
             if self.limit is None:
-                assert 0 <= self.quantity, "[0..+∞)"
+                assert 0 <= self.quantity, msg + "[0..+∞)"
             elif self.limit in (24, 60):
-                assert 0 <= self.quantity < self.limit, f"[0..{self.limit})"
+                assert 0 <= self.quantity < self.limit, msg + f"[0..{self.limit})"
             else:
-                assert 0 <= self.quantity <= self.limit, f"[0..{self.limit}]"
+                assert 0 <= self.quantity <= self.limit, msg + f"[0..{self.limit}]"
             return True
 
     Components: TypeAlias = Iterable[Component]

--- a/src/timedelta_isoformat/__init__.py
+++ b/src/timedelta_isoformat/__init__.py
@@ -121,8 +121,7 @@ class timedelta(datetime.timedelta):
                 raise ValueError(f"unexpected character '{char}'")
 
             yield value, context(char), None
-            value = ""
-            values_found += 1
+            value, values_found = "", values_found + 1
 
         assert values_found, "no measurements found"
         assert next(week_context, None) or values_found == 1, "cannot mix weeks with other units"

--- a/src/timedelta_isoformat/__init__.py
+++ b/src/timedelta_isoformat/__init__.py
@@ -76,6 +76,7 @@ class timedelta(datetime.timedelta):
         """
         time_tokens = iter(("Y", "years", "M", "months", "D", "days", "T", None, "H", "hours", "M", "minutes", "S", "seconds"))
         week_tokens = iter(("W", "weeks"))
+        contexts_encountered = set()
 
         tokens, value = time_tokens, ""
         for char in duration:
@@ -93,13 +94,12 @@ class timedelta(datetime.timedelta):
 
             unit = next(tokens)
             if unit:
+                contexts_encountered.add(tokens)
                 yield value, unit, None
             value = ""
 
-        weeks_parsed = next(week_tokens, None) != "W"
-        time_parsed = next(time_tokens, None) not in ("H", "Y")
-        assert weeks_parsed or time_parsed, "no measurements found"
-        assert weeks_parsed != time_parsed, "cannot mix weeks with other units"
+        assert contexts_encountered, "no measurements found"
+        assert len(contexts_encountered) == 1, "cannot mix weeks with other units"
 
     @classmethod
     def _from_duration(cls, duration: str) -> Measurements:

--- a/src/timedelta_isoformat/__init__.py
+++ b/src/timedelta_isoformat/__init__.py
@@ -103,11 +103,11 @@ class timedelta(datetime.timedelta):
                 while item := context.popitem():
                     designator, unit = item
                     if designator == char:
+                        tokens_consumed += 1
                         break
             except KeyError:
                 raise ValueError(f"unexpected character '{char}'")
 
-            tokens_consumed += 1
             yield value, unit, None
             value = ""
 

--- a/src/timedelta_isoformat/__init__.py
+++ b/src/timedelta_isoformat/__init__.py
@@ -102,13 +102,13 @@ class timedelta(datetime.timedelta):
         time_context = iter(TimeUnit)
         week_context = iter(WeekUnit)
 
-        context, value, unit = date_context, "", None
+        context, value, values_found = date_context, "", 0
         for char in duration:
             if char in _DECIMAL_CHARACTERS:
                 value += char
                 continue
 
-            if char == "T" and context is date_context:
+            if char == "T" and context is not time_context:
                 assert not value, f"expected a unit designator after '{value}'"
                 context = time_context
                 continue
@@ -117,7 +117,6 @@ class timedelta(datetime.timedelta):
                 context = week_context
                 pass
 
-            assert not (unit and context is week_context), "cannot mix weeks with other units"
             for unit in context:
                 if unit == char:
                     break
@@ -126,8 +125,10 @@ class timedelta(datetime.timedelta):
 
             yield value, unit, None
             value = ""
+            values_found += 1
 
-        assert unit, "no measurements found"
+        assert values_found, "no measurements found"
+        assert tuple(week_context) or values_found == 1, "cannot mix weeks with other units"
 
     @classmethod
     def _from_duration(cls, duration: str) -> Measurements:

--- a/src/timedelta_isoformat/__init__.py
+++ b/src/timedelta_isoformat/__init__.py
@@ -118,12 +118,12 @@ class timedelta(datetime.timedelta):
             except StopIteration:
                 raise ValueError(f"unexpected character '{char}'")
 
-            contexts_encountered.add(type(unit))
+            contexts_encountered.add(context)
             yield value, unit.name.lower(), None
             value = ""
 
         assert contexts_encountered, "no measurements found"
-        assert WeekContext not in contexts_encountered or len(contexts_encountered) == 1, "cannot mix weeks with other units"
+        assert week_context not in contexts_encountered or len(contexts_encountered) == 1, "cannot mix weeks with other units"
 
     @classmethod
     def _from_duration(cls, duration: str) -> Measurements:

--- a/src/timedelta_isoformat/__init__.py
+++ b/src/timedelta_isoformat/__init__.py
@@ -100,7 +100,7 @@ class timedelta(datetime.timedelta):
                 continue
 
             if char == "T":
-                assert context is not time_context, f"unexpected character '{char}'"
+                assert context is not time_context, f"unexpected character '{char}' after previous time components"
                 assert context is not week_context, "cannot mix weeks with other units"
                 assert not value, f"missing unit designator after '{value}'"
                 context = time_context

--- a/src/timedelta_isoformat/__init__.py
+++ b/src/timedelta_isoformat/__init__.py
@@ -22,12 +22,13 @@ class timedelta(datetime.timedelta):
             try:
                 assert self.value[0].isdigit()
                 self.quantity = float(self.value)
-                assert self._bounds_check()
+                assert self.valid
             except (AssertionError, IndexError) as exc:
                 msg = f"unable to parse '{self.value}' as a positive decimal"
                 raise ValueError(msg) from exc
 
-        def _bounds_check(self) -> bool:
+        @property
+        def valid(self) -> bool:
             if not self.limit: return True
             inclusive_limit = self.limit not in (24, 60)
             if inclusive_limit and 0 <= self.quantity <= self.limit: return True

--- a/src/timedelta_isoformat/__init__.py
+++ b/src/timedelta_isoformat/__init__.py
@@ -22,13 +22,12 @@ class timedelta(datetime.timedelta):
             try:
                 assert self.value[0].isdigit()
                 self.quantity = float(self.value)
-                assert self.valid
+                assert self._bounds_check()
             except (AssertionError, IndexError) as exc:
                 msg = f"unable to parse '{self.value}' as a positive decimal"
                 raise ValueError(msg) from exc
 
-        @property
-        def valid(self) -> bool:
+        def _bounds_check(self) -> bool:
             if not self.limit: return True
             inclusive_limit = self.limit not in (24, 60)
             if inclusive_limit and 0 <= self.quantity <= self.limit: return True

--- a/src/timedelta_isoformat/__init__.py
+++ b/src/timedelta_isoformat/__init__.py
@@ -16,11 +16,14 @@ Measurements: TypeAlias = Iterable[Tuple[TimedeltaArgument, float]]
 
 class ParsingContext:
     remaining_tokens: Iterable[Token]
-    units: Dict[Token, TimedeltaArgument]
+    token_to_timedelta_arg: Dict[Token, TimedeltaArgument]
 
-    def __init__(self, units: Dict[Token, TimedeltaArgument]):
-        self.units = units
-        self.remaining_tokens = iter(units)
+    def __init__(
+        self,
+        token_to_timedelta_arg: Dict[Token, TimedeltaArgument],
+    ):
+        self.token_to_timedelta_arg = token_to_timedelta_arg
+        self.remaining_tokens = iter(token_to_timedelta_arg)
 
 class timedelta(datetime.timedelta):
     """Subclass of :py:class:`datetime.timedelta` with additional methods to implement
@@ -137,7 +140,7 @@ class timedelta(datetime.timedelta):
             if char not in context.remaining_tokens:
                 raise ValueError(f"unexpected character '{char}'")
 
-            yield value, context.units[char], None
+            yield value, context.token_to_timedelta_arg[char], None
             value = ""
 
         weeks_parsed = next(week_context.remaining_tokens, None) != "W"

--- a/src/timedelta_isoformat/__init__.py
+++ b/src/timedelta_isoformat/__init__.py
@@ -99,7 +99,7 @@ class timedelta(datetime.timedelta):
                 continue
 
             if char == "T" and context is date_context:
-                assert not head + tail, f"missing unit designator after '{head}{tail}'"
+                assert not head + tail, f"missing unit designator after '{head + tail}'"
                 context = time_context
                 continue
 

--- a/src/timedelta_isoformat/__init__.py
+++ b/src/timedelta_isoformat/__init__.py
@@ -99,16 +99,18 @@ class timedelta(datetime.timedelta):
                 head, tail = tail, "."
                 continue
 
-            if char == "T" and context is date_context:
+            if char == "T":
+                assert context is not time_context, f"unexpected character '{char}'"
+                assert context is not week_context, "cannot mix weeks with other units"
                 assert not head + tail, f"missing unit designator after '{head + tail}'"
                 context = time_context
                 continue
 
             if char == "W":
+                assert not unit, "cannot mix weeks with other units"
                 context = week_context
                 pass
 
-            assert not (unit and context is week_context), "cannot mix weeks with other units"
             for delimiter, unit in context:
                 if char == delimiter:
                     yield head + tail, unit, None

--- a/src/timedelta_isoformat/__init__.py
+++ b/src/timedelta_isoformat/__init__.py
@@ -8,19 +8,19 @@ _DECIMAL_CHARACTERS = frozenset("0123456789" + ",.")
 
 
 class DateUnit(StrEnum):
-    years = "Y"
-    months = "M"
-    days = "D"
+    Y = YEARS = "years"
+    M = MONTHS = "months"
+    D = DAYS = "days"
 
 
 class TimeUnit(StrEnum):
-    hours = "H"
-    minutes = "M"
-    seconds = "S"
+    H = HOURS = "hours"
+    M = MINUTES = "minutes"
+    S = SECONDS = "seconds"
 
 
 class WeekUnit(StrEnum):
-    weeks = "W"
+    W = WEEKS = "weeks"
 
 
 RawValue: TypeAlias = str
@@ -45,22 +45,22 @@ class timedelta(datetime.timedelta):
         match tuple(segment):
             # YYYY-DDD
             case _, _, _, _, "-", _, _, _:
-                yield segment[0:4], DateUnit.years, None
-                yield segment[5:8], DateUnit.days, 366
+                yield segment[0:4], DateUnit.YEARS, None
+                yield segment[5:8], DateUnit.DAYS, 366
             # YYYY-MM-DD
             case _, _, _, _, "-", _, _, "-", _, _:
-                yield segment[0:4], DateUnit.years, None
-                yield segment[5:7], DateUnit.months, 12
-                yield segment[8:10], DateUnit.days, 31
+                yield segment[0:4], DateUnit.YEARS, None
+                yield segment[5:7], DateUnit.MONTHS, 12
+                yield segment[8:10], DateUnit.DAYS, 31
             # YYYYDDD
             case _, _, _, _, _, _, _:
-                yield segment[0:4], DateUnit.years, None
-                yield segment[4:7], DateUnit.days, 366
+                yield segment[0:4], DateUnit.YEARS, None
+                yield segment[4:7], DateUnit.DAYS, 366
             # YYYYMMDD
             case _, _, _, _, _, _, _, _:
-                yield segment[0:4], DateUnit.years, None
-                yield segment[4:6], DateUnit.months, 12
-                yield segment[6:8], DateUnit.days, 31
+                yield segment[0:4], DateUnit.YEARS, None
+                yield segment[4:6], DateUnit.MONTHS, 12
+                yield segment[6:8], DateUnit.DAYS, 31
             case _:
                 raise ValueError(f"unable to parse '{segment}' into date components")
 
@@ -69,24 +69,24 @@ class timedelta(datetime.timedelta):
         match tuple(segment):
             # HH:MM:SS[.ssssss]
             case _, _, ":", _, _, ":", _, _, ".", *_:
-                yield segment[0:2], TimeUnit.hours, 24
-                yield segment[3:5], TimeUnit.minutes, 60
-                yield segment[6:15], TimeUnit.seconds, 60
+                yield segment[0:2], TimeUnit.HOURS, 24
+                yield segment[3:5], TimeUnit.MINUTES, 60
+                yield segment[6:15], TimeUnit.SECONDS, 60
             # HH:MM:SS
             case _, _, ":", _, _, ":", _, _:
-                yield segment[0:2], TimeUnit.hours, 24
-                yield segment[3:5], TimeUnit.minutes, 60
-                yield segment[6:8], TimeUnit.seconds, 60
+                yield segment[0:2], TimeUnit.HOURS, 24
+                yield segment[3:5], TimeUnit.MINUTES, 60
+                yield segment[6:8], TimeUnit.SECONDS, 60
             # HHMMSS[.ssssss]
             case _, _, _, _, _, _, ".", *_:
-                yield segment[0:2], TimeUnit.hours, 24
-                yield segment[2:4], TimeUnit.minutes, 60
-                yield segment[4:13], TimeUnit.seconds, 60
+                yield segment[0:2], TimeUnit.HOURS, 24
+                yield segment[2:4], TimeUnit.MINUTES, 60
+                yield segment[4:13], TimeUnit.SECONDS, 60
             # HHMMSS
             case _, _, _, _, _, _:
-                yield segment[0:2], TimeUnit.hours, 24
-                yield segment[2:4], TimeUnit.minutes, 60
-                yield segment[4:6], TimeUnit.seconds, 60
+                yield segment[0:2], TimeUnit.HOURS, 24
+                yield segment[2:4], TimeUnit.MINUTES, 60
+                yield segment[4:6], TimeUnit.SECONDS, 60
             case _:
                 raise ValueError(f"unable to parse '{segment}' into time components")
 
@@ -118,7 +118,7 @@ class timedelta(datetime.timedelta):
                 pass
 
             while unit := next(context, None):
-                if unit == char:
+                if unit.name == char:
                     break
             else:
                 raise ValueError(f"unexpected character '{char}'")
@@ -165,10 +165,10 @@ class timedelta(datetime.timedelta):
                 msg = f"unable to parse '{value}' as a positive decimal"
                 raise ValueError(msg) from exc
             if quantity:
-                yield unit.name, quantity
+                yield unit, quantity
             if limit and (quantity > limit if inclusive_limit else quantity >= limit):
                 bounds = f"[0..{limit}" + ("]" if inclusive_limit else ")")
-                raise ValueError(f"{unit.name} value of {value} exceeds range {bounds}")
+                raise ValueError(f"{unit} value of {value} exceeds range {bounds}")
 
     @classmethod
     def fromisoformat(cls, duration: str) -> "timedelta":

--- a/src/timedelta_isoformat/__init__.py
+++ b/src/timedelta_isoformat/__init__.py
@@ -2,7 +2,7 @@
 import datetime
 from typing import Iterable, Tuple, TypeAlias
 
-_DECIMAL_CHARACTERS = frozenset("0123456789" + ",.")
+_NUMERIC_CHARACTERS = frozenset("0123456789" + ",.")
 
 
 class timedelta(datetime.timedelta):
@@ -80,7 +80,7 @@ class timedelta(datetime.timedelta):
 
         tokens, value = date_tokens, ""
         for char in duration:
-            if char in _DECIMAL_CHARACTERS:
+            if char in _NUMERIC_CHARACTERS:
                 value += char
                 continue
 

--- a/src/timedelta_isoformat/__init__.py
+++ b/src/timedelta_isoformat/__init__.py
@@ -74,16 +74,21 @@ class timedelta(datetime.timedelta):
         in order of largest-to-smallest unit from left-to-right (with the exception of
         week measurements, which must be the only measurement in the string if present).
         """
-        time_tokens = iter(("Y", "years", "M", "months", "D", "days", "T", None, "H", "hours", "M", "minutes", "S", "seconds"))
+        date_tokens = iter(("Y", "years", "M", "months", "D", "days"))
+        time_tokens = iter(("H", "hours", "M", "minutes", "S", "seconds"))
         week_tokens = iter(("W", "weeks"))
 
-        tokens, value = time_tokens, ""
+        tokens, value = date_tokens, ""
         for char in duration:
             if char in _DECIMAL_CHARACTERS:
                 value += char
                 continue
 
-            if char == "W" and tokens is time_tokens:
+            if char == "T" and tokens is not time_tokens:
+                tokens, value = time_tokens, ""
+                continue
+
+            if char == "W" and tokens is date_tokens:
                 tokens = week_tokens
                 pass
 
@@ -91,13 +96,11 @@ class timedelta(datetime.timedelta):
             if char not in tokens:
                 raise ValueError(f"unexpected character '{char}'")
 
-            unit = next(tokens)
-            if unit:
-                yield value, unit, None
+            yield value, next(tokens), None
             value = ""
 
         weeks_parsed = next(week_tokens, None) != "W"
-        time_parsed = next(time_tokens, None) not in ("H", "Y")
+        time_parsed = next(time_tokens, None) != "H" or next(date_tokens, None) != "Y"
         assert weeks_parsed or time_parsed, "no measurements found"
         assert weeks_parsed != time_parsed, "cannot mix weeks with other units"
 

--- a/src/timedelta_isoformat/__init__.py
+++ b/src/timedelta_isoformat/__init__.py
@@ -103,14 +103,15 @@ class timedelta(datetime.timedelta):
                 context = week_context
                 pass
 
-            # Note: this advances and may exhaust the token iterator
             assert not (unit and context is week_context), "cannot mix weeks with other units"
-            if char not in context:
-                raise ValueError(f"unexpected character '{char}'")
+            if char in context:
+                unit = next(context)
+                yield value, unit, None
+                value = ""
+                continue
 
-            unit = next(context)
-            yield value, unit, None
-            value = ""
+            raise ValueError(f"unexpected character '{char}'")
+
 
         assert unit, "no measurements found"
 

--- a/src/timedelta_isoformat/__init__.py
+++ b/src/timedelta_isoformat/__init__.py
@@ -105,7 +105,6 @@ class timedelta(datetime.timedelta):
                 continue
 
             if char == "T" and context is not time_context:
-                assert not value, f"expected a unit designator after '{value}'"
                 context, value = time_context, ""
                 continue
 

--- a/src/timedelta_isoformat/__init__.py
+++ b/src/timedelta_isoformat/__init__.py
@@ -28,12 +28,21 @@ class timedelta(datetime.timedelta):
                 raise ValueError(msg) from exc
 
         def _bounds_check(self) -> bool:
-            if not self.limit: return True
+            if not self.limit:
+                return True
+
             inclusive_limit = self.limit not in (24, 60)
-            if inclusive_limit and 0 <= self.quantity <= self.limit: return True
-            if not inclusive_limit and 0 <= self.quantity < self.limit: return True
+            if inclusive_limit:
+                if 0 <= self.quantity <= self.limit:
+                    return True
+            else:
+                if 0 <= self.quantity < self.limit:
+                    return True
+
             bounds = f"[0..{self.limit}" + ("]" if inclusive_limit else ")")
-            raise ValueError(f"{self.unit} value of {self.value} exceeds range {bounds}")
+            raise ValueError(
+                f"{self.unit} value of {self.value} exceeds range {bounds}"
+            )
 
     Components: TypeAlias = Iterable[Component]
 
@@ -43,7 +52,6 @@ class timedelta(datetime.timedelta):
     @classmethod
     def _parse_date(cls, segment: str) -> Components:
         match tuple(segment):
-
             # YYYY-DDD
             case _, _, _, _, "-", _, _, _:
                 yield cls.Component(segment[0:4], "years")
@@ -72,7 +80,6 @@ class timedelta(datetime.timedelta):
     @classmethod
     def _parse_time(cls, segment: str) -> Components:
         match tuple(segment):
-
             # HH:MM:SS[.ssssss]
             case _, _, ":", _, _, ":", _, _, ".", *_:
                 yield cls.Component(segment[0:2], "hours", 24)
@@ -127,7 +134,9 @@ class timedelta(datetime.timedelta):
                 context = week_context
                 pass
 
-            assert not (context is week_context and unit), "cannot mix weeks with other units"
+            assert not (
+                context is week_context and unit
+            ), "cannot mix weeks with other units"
             for delimiter, unit in context:
                 if char == delimiter:
                     yield cls.Component(value, unit)
@@ -168,7 +177,13 @@ class timedelta(datetime.timedelta):
         :raises: `ValueError` with an explanatory message when parsing fails
         """
         try:
-            return cls(**{m.unit: m.quantity for m in cls._parse_duration(duration) if m.quantity})
+            return cls(
+                **{
+                    m.unit: m.quantity
+                    for m in cls._parse_duration(duration)
+                    if m.quantity
+                }
+            )
         except (AssertionError, ValueError) as exc:
             raise ValueError(f"could not parse duration '{duration}': {exc}") from exc
 

--- a/src/timedelta_isoformat/__init__.py
+++ b/src/timedelta_isoformat/__init__.py
@@ -28,13 +28,18 @@ class timedelta(datetime.timedelta):
                 raise ValueError(msg) from exc
 
         def _bounds_check(self) -> bool:
-            upper_limit_inclusive = self.limit not in (24, 60) if self.limit else None
-            match upper_limit_inclusive:
-                case None if 0 <= self.quantity: return True
-                case True if 0 <= self.quantity <= self.limit: return True
-                case False if 0 <= self.quantity < self.limit: return True
+            if not self.limit:
+                return True
 
-            bounds = f"[0..{self.limit}" + ("]" if upper_limit_inclusive else ")")
+            inclusive_limit = self.limit not in (24, 60)
+            if inclusive_limit:
+                if 0 <= self.quantity <= self.limit:
+                    return True
+            else:
+                if 0 <= self.quantity < self.limit:
+                    return True
+
+            bounds = f"[0..{self.limit}" + ("]" if inclusive_limit else ")")
             raise ValueError(f"{self.unit} value of {self.value} exceeds range {bounds}")
 
     Components: TypeAlias = Iterable[Component]

--- a/src/timedelta_isoformat/__init__.py
+++ b/src/timedelta_isoformat/__init__.py
@@ -19,6 +19,7 @@ class timedelta(datetime.timedelta):
     @staticmethod
     def _from_date(segment: str) -> Components:
         match tuple(segment):
+
             # YYYY-DDD
             case _, _, _, _, "-", _, _, _:
                 yield segment[0:4], "years", None
@@ -47,6 +48,7 @@ class timedelta(datetime.timedelta):
     @staticmethod
     def _from_time(segment: str) -> Components:
         match tuple(segment):
+
             # HH:MM:SS[.ssssss]
             case _, _, ":", _, _, ":", _, _, ".", *_:
                 yield segment[0:2], "hours", 24

--- a/src/timedelta_isoformat/__init__.py
+++ b/src/timedelta_isoformat/__init__.py
@@ -98,9 +98,9 @@ class timedelta(datetime.timedelta):
         in order of largest-to-smallest unit from left-to-right (with the exception of
         week measurements, which must be the only measurement in the string if present).
         """
-        date_context = iter((DateUnit.years, DateUnit.months, DateUnit.days))
-        time_context = iter((TimeUnit.hours, TimeUnit.minutes, TimeUnit.seconds))
-        week_context = iter((WeekUnit.weeks,))
+        date_context = iter(DateUnit)
+        time_context = iter(TimeUnit)
+        week_context = iter(WeekUnit)
 
         context, value, unit = date_context, "", None
         for char in duration:

--- a/src/timedelta_isoformat/__init__.py
+++ b/src/timedelta_isoformat/__init__.py
@@ -111,7 +111,7 @@ class timedelta(datetime.timedelta):
 
             if char == "T" and context is not time_context:
                 assert not value, f"expected a unit designator after '{value}'"
-                context, value = time_context, ""
+                context = time_context
                 continue
 
             if char == "W" and context is date_context:

--- a/src/timedelta_isoformat/__init__.py
+++ b/src/timedelta_isoformat/__init__.py
@@ -28,10 +28,17 @@ class timedelta(datetime.timedelta):
                 raise ValueError(msg) from exc
 
         def _bounds_check(self) -> bool:
-            if not self.limit: return True
+            if not self.limit:
+                return True
+
             inclusive_limit = self.limit not in (24, 60)
-            if inclusive_limit and 0 <= self.quantity <= self.limit: return True
-            if not inclusive_limit and 0 <= self.quantity < self.limit: return True
+            if inclusive_limit:
+                if 0 <= self.quantity <= self.limit:
+                    return True
+            else:
+                if 0 <= self.quantity < self.limit:
+                    return True
+
             bounds = f"[0..{self.limit}" + ("]" if inclusive_limit else ")")
             raise ValueError(f"{self.unit} value of {self.value} exceeds range {bounds}")
 

--- a/src/timedelta_isoformat/__init__.py
+++ b/src/timedelta_isoformat/__init__.py
@@ -102,7 +102,8 @@ class timedelta(datetime.timedelta):
         time_context = iter(TimeUnit)
         week_context = iter(WeekUnit)
 
-        context, value, values_found = date_context, "", 0
+        context, value = date_context, ""
+        values_found = 0
         for char in duration:
             if char in _DECIMAL_CHARACTERS:
                 value += char

--- a/src/timedelta_isoformat/__init__.py
+++ b/src/timedelta_isoformat/__init__.py
@@ -94,8 +94,8 @@ class timedelta(datetime.timedelta):
                 continue
 
             if char in decimal_points:
-                decimal_points.clear()
                 value += "."
+                decimal_points.clear()
                 continue
 
             if char == "T" and context is date_context:

--- a/src/timedelta_isoformat/__init__.py
+++ b/src/timedelta_isoformat/__init__.py
@@ -1,5 +1,6 @@
 """Supplemental ISO8601 duration format support for :py:class:`datetime.timedelta`"""
 import datetime
+from enum import StrEnum
 from typing import Iterable, Tuple, TypeAlias
 from dataclasses import dataclass
 
@@ -13,21 +14,18 @@ MeasuredValue: TypeAlias = float
 Components: TypeAlias = Iterable[Tuple[RawValue, Unit, MeasurementLimit]]
 Measurements: TypeAlias = Iterable[Tuple[Unit, MeasuredValue]]
 
-DateContext = {
-    "Y": "years",
-    "M": "months",
-    "D": "days",
-}
+class DateContext(StrEnum):
+    YEARS = "Y"
+    MONTHS = "M"
+    DAYS = "D"
 
-TimeContext = {
-    "H": "hours",
-    "M": "minutes",
-    "S": "seconds",
-}
+class TimeContext(StrEnum):
+    HOURS = "H"
+    MINUTES = "M"
+    SECONDS = "S"
 
-WeekContext = {
-    "W": "weeks",
-}
+class WeekContext(StrEnum):
+    WEEKS = "W"
 
 
 class timedelta(datetime.timedelta):
@@ -96,9 +94,9 @@ class timedelta(datetime.timedelta):
         in order of largest-to-smallest unit from left-to-right (with the exception of
         week measurements, which must be the only measurement in the string if present).
         """
-        date_context = iter(DateContext.items())
-        time_context = iter(TimeContext.items())
-        week_context = iter(WeekContext.items())
+        date_context = iter(DateContext)
+        time_context = iter(TimeContext)
+        week_context = iter(WeekContext)
 
         contexts_encountered, context, value = set(), date_context, ""
         for char in duration:
@@ -115,18 +113,17 @@ class timedelta(datetime.timedelta):
                 context = week_context
                 pass
 
-            for designator, unit in context:
-                if designator == char:
-                    break
-            else:
+            try:
+                while (unit := next(context)) != char: continue
+            except StopIteration:
                 raise ValueError(f"unexpected character '{char}'")
 
-            contexts_encountered.add(context)
-            yield value, unit, None
+            contexts_encountered.add(type(unit))
+            yield value, unit.name.lower(), None
             value = ""
 
         assert contexts_encountered, "no measurements found"
-        assert week_context not in contexts_encountered or len(contexts_encountered) == 1, "cannot mix weeks with other units"
+        assert WeekContext not in contexts_encountered or len(contexts_encountered) == 1, "cannot mix weeks with other units"
 
     @classmethod
     def _from_duration(cls, duration: str) -> Measurements:

--- a/src/timedelta_isoformat/__init__.py
+++ b/src/timedelta_isoformat/__init__.py
@@ -28,13 +28,13 @@ class timedelta(datetime.timedelta):
                 raise ValueError(msg) from exc
 
         def _bounds_check(self) -> bool:
-            upper_limit_inclusive = self.limit not in (24, 60) if self.limit else None
-            match upper_limit_inclusive:
-                case None if 0 <= self.quantity: return True
-                case True if 0 <= self.quantity <= self.limit: return True
-                case False if 0 <= self.quantity < self.limit: return True
+            inclusive_limit = self.limit not in (24, 60)
+            match self.limit, inclusive_limit:
+                case None, _ if 0 <= self.quantity: return True
+                case _, True if 0 <= self.quantity <= self.limit: return True
+                case _, False if 0 <= self.quantity < self.limit: return True
 
-            bounds = f"[0..{self.limit}" + ("]" if upper_limit_inclusive else ")")
+            bounds = f"[0..{self.limit}" + ("]" if inclusive_limit else ")")
             raise ValueError(f"{self.unit} value of {self.value} exceeds range {bounds}")
 
     Components: TypeAlias = Iterable[Component]

--- a/src/timedelta_isoformat/__init__.py
+++ b/src/timedelta_isoformat/__init__.py
@@ -106,7 +106,7 @@ class timedelta(datetime.timedelta):
             else:
                 raise ValueError(f"unexpected character '{char}'")
 
-            assert len(week_context) or not values_found, "cannot mix weeks with other units"
+            assert week_context or not values_found, "cannot mix weeks with other units"
             yield value, unit, None
             value, values_found = "", True
 

--- a/src/timedelta_isoformat/__init__.py
+++ b/src/timedelta_isoformat/__init__.py
@@ -1,29 +1,10 @@
 """Supplemental ISO8601 duration format support for :py:class:`datetime.timedelta`"""
 import datetime
-from typing import Iterable, Tuple, TypeAlias, Dict
-from dataclasses import dataclass
+from typing import Iterable, Tuple, TypeAlias
 
 _DIGITS, _DECIMAL_SIGNS = frozenset("0123456789"), frozenset(",.")
 _FORMAT = _DIGITS | _DECIMAL_SIGNS
 
-
-Token: TypeAlias = str
-TimedeltaArgument: TypeAlias = str
-UnparsedValue: TypeAlias = str
-ValueLimit: TypeAlias = int | None
-Components: TypeAlias = Iterable[Tuple[UnparsedValue, TimedeltaArgument, ValueLimit]]
-Measurements: TypeAlias = Iterable[Tuple[TimedeltaArgument, float]]
-
-class ParsingContext:
-    unparsed_valid_tokens: Iterable[Token]
-    token_to_timedelta_arg: Dict[Token, TimedeltaArgument]
-
-    def __init__(
-        self,
-        token_to_timedelta_arg: Dict[Token, TimedeltaArgument],
-    ):
-        self.token_to_timedelta_arg = token_to_timedelta_arg
-        self.unparsed_valid_tokens = iter(token_to_timedelta_arg)
 
 class timedelta(datetime.timedelta):
     """Subclass of :py:class:`datetime.timedelta` with additional methods to implement
@@ -104,47 +85,33 @@ class timedelta(datetime.timedelta):
         in order of largest-to-smallest unit from left-to-right (with the exception of
         week measurements, which must be the only measurement in the string if present).
         """
-        date_context = ParsingContext(
-            {
-                "Y": "years",
-                "M": "months",
-                "D": "days",
-            }
-        )
-        time_context = ParsingContext(
-            {
-                "H": "hours",
-                "M": "minutes",
-                "S": "seconds",
-            }
-        )
-        week_context = ParsingContext(
-            {"W": "weeks"}
-        )
+        date_tokens = iter(("Y", "years", "M", "months", "D", "days"))
+        time_tokens = iter(("H", "hours", "M", "minutes", "S", "seconds"))
+        week_tokens = iter(("W", "weeks"))
 
-        context, value = date_context, ""
+        tokens, value = date_tokens, ""
         for char in duration:
             if char in _FORMAT:
                 value += char
                 continue
 
-            if char == "T" and context is not time_context:
-                context, value = time_context, ""
+            if char == "T" and tokens is not time_tokens:
+                tokens, value = time_tokens, ""
                 continue
 
-            if char == "W" and context is date_context:
-                context = week_context
+            if char == "W" and tokens is date_tokens:
+                tokens = week_tokens
                 pass
 
             # Note: this advances and may exhaust the token iterator
-            if char not in context.unparsed_valid_tokens:
+            if char not in tokens:
                 raise ValueError(f"unexpected character '{char}'")
 
-            yield value, context.token_to_timedelta_arg[char], None
+            yield value, next(tokens), None
             value = ""
 
-        weeks_parsed = next(week_context.unparsed_valid_tokens, None) != "W"
-        time_parsed = next(time_context.unparsed_valid_tokens, None) != "H" or next(date_context.unparsed_valid_tokens, None) != "Y"
+        weeks_parsed = next(week_tokens, None) != "W"
+        time_parsed = next(time_tokens, None) != "H" or next(date_tokens, None) != "Y"
         assert weeks_parsed or time_parsed, "no measurements found"
         assert weeks_parsed != time_parsed, "cannot mix weeks with other units"
 

--- a/src/timedelta_isoformat/__init__.py
+++ b/src/timedelta_isoformat/__init__.py
@@ -33,10 +33,9 @@ class timedelta(datetime.timedelta):
                 case None, _ if 0 <= self.quantity: return True
                 case _, True if 0 <= self.quantity <= self.limit: return True
                 case _, False if 0 <= self.quantity < self.limit: return True
-                case _:
-                    bounds = f"[0..{self.limit}" + ("]" if inclusive_limit else ")")
-                    msg = f"{self.unit} value of {self.value} exceeds range {bounds}"
-                    raise ValueError(msg)
+
+            bounds = f"[0..{self.limit}" + ("]" if inclusive_limit else ")")
+            raise ValueError(f"{self.unit} value of {self.value} exceeds range {bounds}")
 
     Components: TypeAlias = Iterable[Component]
 

--- a/src/timedelta_isoformat/__init__.py
+++ b/src/timedelta_isoformat/__init__.py
@@ -1,7 +1,7 @@
 """Supplemental ISO8601 duration format support for :py:class:`datetime.timedelta`"""
 from dataclasses import dataclass
 import datetime
-from typing import Iterable, Tuple, TypeAlias
+from typing import Iterable, TypeAlias
 
 _NUMBER_FORMAT = frozenset("0123456789,.")
 

--- a/src/timedelta_isoformat/__init__.py
+++ b/src/timedelta_isoformat/__init__.py
@@ -94,7 +94,8 @@ class timedelta(datetime.timedelta):
                 tail += char
                 continue
 
-            if char in _DECIMAL_POINTS and not head:
+            if char in _DECIMAL_POINTS:
+                assert not head, f"unexpected character '{char}'"
                 head, tail = tail, "."
                 continue
 

--- a/src/timedelta_isoformat/__init__.py
+++ b/src/timedelta_isoformat/__init__.py
@@ -98,9 +98,9 @@ class timedelta(datetime.timedelta):
         in order of largest-to-smallest unit from left-to-right (with the exception of
         week measurements, which must be the only measurement in the string if present).
         """
-        date_context = iter(DateUnit)
-        time_context = iter(TimeUnit)
-        week_context = iter(WeekUnit)
+        date_context = iter((DateUnit.years, DateUnit.months, DateUnit.days))
+        time_context = iter((TimeUnit.hours, TimeUnit.minutes, TimeUnit.seconds))
+        week_context = iter((WeekUnit.weeks,))
 
         context, value, unit = date_context, "", None
         for char in duration:

--- a/src/timedelta_isoformat/__init__.py
+++ b/src/timedelta_isoformat/__init__.py
@@ -105,7 +105,7 @@ class timedelta(datetime.timedelta):
 
             assert not (unit and context is week_context), "cannot mix weeks with other units"
             for delimiter, unit in context:
-                if delimiter == char:
+                if char == delimiter:
                     yield value, unit, None
                     value = ""
                     break

--- a/src/timedelta_isoformat/__init__.py
+++ b/src/timedelta_isoformat/__init__.py
@@ -99,7 +99,7 @@ class timedelta(datetime.timedelta):
                 context = time_context
                 continue
 
-            if char == "W" and context is date_context:
+            if char == "W":
                 context = week_context
                 pass
 

--- a/src/timedelta_isoformat/__init__.py
+++ b/src/timedelta_isoformat/__init__.py
@@ -107,10 +107,10 @@ class timedelta(datetime.timedelta):
                 continue
 
             if char == "W":
-                assert not unit, "cannot mix weeks with other units"
                 context = week_context
                 pass
 
+            assert not (context is week_context and unit), "cannot mix weeks with other units"
             for delimiter, unit in context:
                 if char == delimiter:
                     yield head + tail, unit, None

--- a/src/timedelta_isoformat/__init__.py
+++ b/src/timedelta_isoformat/__init__.py
@@ -8,17 +8,17 @@ _FORMAT = _DIGITS | _DECIMAL_SIGNS
 
 
 Token: TypeAlias = str
-Unit: TypeAlias = str
+TimedeltaArgument: TypeAlias = str
 UnparsedValue: TypeAlias = str
 ValueLimit: TypeAlias = int | None
-Components: TypeAlias = Iterable[Tuple[UnparsedValue, Unit, ValueLimit]]
-Measurements: TypeAlias = Iterable[Tuple[Unit, float]]
+Components: TypeAlias = Iterable[Tuple[UnparsedValue, TimedeltaArgument, ValueLimit]]
+Measurements: TypeAlias = Iterable[Tuple[TimedeltaArgument, float]]
 
 class ParsingContext:
     remaining_tokens: Iterable[Token]
-    units: Dict[Token, Unit]
+    units: Dict[Token, TimedeltaArgument]
 
-    def __init__(self, units: Dict[Token, Unit]):
+    def __init__(self, units: Dict[Token, TimedeltaArgument]):
         self.units = units
         self.remaining_tokens = iter(units)
 

--- a/src/timedelta_isoformat/__init__.py
+++ b/src/timedelta_isoformat/__init__.py
@@ -98,9 +98,9 @@ class timedelta(datetime.timedelta):
         in order of largest-to-smallest unit from left-to-right (with the exception of
         week measurements, which must be the only measurement in the string if present).
         """
-        date_context = [DateUnit.days, DateUnit.months, DateUnit.years]
-        time_context = [TimeUnit.seconds, TimeUnit.minutes, TimeUnit.hours]
-        week_context = [WeekUnit.weeks]
+        date_context = iter((DateUnit.years, DateUnit.months, DateUnit.days))
+        time_context = iter((TimeUnit.hours, TimeUnit.minutes, TimeUnit.seconds))
+        week_context = iter((WeekUnit.weeks,))
 
         context, value, unit = date_context, "", None
         for char in duration:
@@ -118,11 +118,8 @@ class timedelta(datetime.timedelta):
                 pass
 
             assert not (unit and context is week_context), "cannot mix weeks with other units"
-            try:
-                while (unit := context.pop()) != char:
-                    continue
-            except IndexError:
-                raise ValueError(f"unexpected character '{char}'")
+            unit = next(filter(char.__eq__, context), None)
+            assert unit, f"unexpected character '{char}'"
 
             yield value, unit, None
             value = ""

--- a/src/timedelta_isoformat/__init__.py
+++ b/src/timedelta_isoformat/__init__.py
@@ -98,11 +98,11 @@ class timedelta(datetime.timedelta):
         in order of largest-to-smallest unit from left-to-right (with the exception of
         week measurements, which must be the only measurement in the string if present).
         """
-        date_context = {"D": "days", "M": "months", "Y": "years"}
-        time_context = {"S": "seconds", "M": "minutes", "H": "hours"}
-        week_context = {"W": "weeks"}
+        date_context = iter(DateUnit)
+        time_context = iter(TimeUnit)
+        week_context = iter(WeekUnit)
 
-        context, value, values_found = date_context, "", False
+        context, value, values_found = date_context, "", 0
         for char in duration:
             if char in _DECIMAL_CHARACTERS:
                 value += char
@@ -117,18 +117,17 @@ class timedelta(datetime.timedelta):
                 context = week_context
                 pass
 
-            while context:
-                designator, unit = context.popitem()
-                if designator == char:
+            while unit := next(context, None):
+                if unit.name == char:
                     break
             else:
                 raise ValueError(f"unexpected character '{char}'")
 
-            assert len(week_context) or not values_found, "cannot mix weeks with other units"
             yield value, unit, None
-            value, values_found = "", True
+            value, values_found = "", values_found + 1
 
         assert values_found, "no measurements found"
+        assert next(week_context, None) or values_found == 1, "cannot mix weeks with other units"
 
     @classmethod
     def _from_duration(cls, duration: str) -> Measurements:

--- a/src/timedelta_isoformat/__init__.py
+++ b/src/timedelta_isoformat/__init__.py
@@ -2,7 +2,7 @@
 import datetime
 from typing import Iterable, Tuple, TypeAlias
 
-_NUMERIC_CHARACTERS = frozenset("0123456789" + ",.")
+_DECIMAL_CHARACTERS = frozenset("0123456789" + ",.")
 
 
 class timedelta(datetime.timedelta):
@@ -90,7 +90,7 @@ class timedelta(datetime.timedelta):
 
         tokens, value, unit = date_tokens, "", None
         for char in duration:
-            if char in _NUMERIC_CHARACTERS:
+            if char in _DECIMAL_CHARACTERS:
                 value += char
                 continue
 

--- a/src/timedelta_isoformat/__init__.py
+++ b/src/timedelta_isoformat/__init__.py
@@ -8,19 +8,19 @@ _DECIMAL_CHARACTERS = frozenset("0123456789" + ",.")
 
 
 class DateUnit(StrEnum):
-    Y = YEARS = "years"
-    M = MONTHS = "months"
-    D = DAYS = "days"
+    years = "Y"
+    months = "M"
+    days = "D"
 
 
 class TimeUnit(StrEnum):
-    H = HOURS = "hours"
-    M = MINUTES = "minutes"
-    S = SECONDS = "seconds"
+    hours = "H"
+    minutes = "M"
+    seconds = "S"
 
 
 class WeekUnit(StrEnum):
-    W = WEEKS = "weeks"
+    weeks = "W"
 
 
 RawValue: TypeAlias = str
@@ -45,22 +45,22 @@ class timedelta(datetime.timedelta):
         match tuple(segment):
             # YYYY-DDD
             case _, _, _, _, "-", _, _, _:
-                yield segment[0:4], DateUnit.YEARS, None
-                yield segment[5:8], DateUnit.DAYS, 366
+                yield segment[0:4], DateUnit.years, None
+                yield segment[5:8], DateUnit.days, 366
             # YYYY-MM-DD
             case _, _, _, _, "-", _, _, "-", _, _:
-                yield segment[0:4], DateUnit.YEARS, None
-                yield segment[5:7], DateUnit.MONTHS, 12
-                yield segment[8:10], DateUnit.DAYS, 31
+                yield segment[0:4], DateUnit.years, None
+                yield segment[5:7], DateUnit.months, 12
+                yield segment[8:10], DateUnit.days, 31
             # YYYYDDD
             case _, _, _, _, _, _, _:
-                yield segment[0:4], DateUnit.YEARS, None
-                yield segment[4:7], DateUnit.DAYS, 366
+                yield segment[0:4], DateUnit.years, None
+                yield segment[4:7], DateUnit.days, 366
             # YYYYMMDD
             case _, _, _, _, _, _, _, _:
-                yield segment[0:4], DateUnit.YEARS, None
-                yield segment[4:6], DateUnit.MONTHS, 12
-                yield segment[6:8], DateUnit.DAYS, 31
+                yield segment[0:4], DateUnit.years, None
+                yield segment[4:6], DateUnit.months, 12
+                yield segment[6:8], DateUnit.days, 31
             case _:
                 raise ValueError(f"unable to parse '{segment}' into date components")
 
@@ -69,24 +69,24 @@ class timedelta(datetime.timedelta):
         match tuple(segment):
             # HH:MM:SS[.ssssss]
             case _, _, ":", _, _, ":", _, _, ".", *_:
-                yield segment[0:2], TimeUnit.HOURS, 24
-                yield segment[3:5], TimeUnit.MINUTES, 60
-                yield segment[6:15], TimeUnit.SECONDS, 60
+                yield segment[0:2], TimeUnit.hours, 24
+                yield segment[3:5], TimeUnit.minutes, 60
+                yield segment[6:15], TimeUnit.seconds, 60
             # HH:MM:SS
             case _, _, ":", _, _, ":", _, _:
-                yield segment[0:2], TimeUnit.HOURS, 24
-                yield segment[3:5], TimeUnit.MINUTES, 60
-                yield segment[6:8], TimeUnit.SECONDS, 60
+                yield segment[0:2], TimeUnit.hours, 24
+                yield segment[3:5], TimeUnit.minutes, 60
+                yield segment[6:8], TimeUnit.seconds, 60
             # HHMMSS[.ssssss]
             case _, _, _, _, _, _, ".", *_:
-                yield segment[0:2], TimeUnit.HOURS, 24
-                yield segment[2:4], TimeUnit.MINUTES, 60
-                yield segment[4:13], TimeUnit.SECONDS, 60
+                yield segment[0:2], TimeUnit.hours, 24
+                yield segment[2:4], TimeUnit.minutes, 60
+                yield segment[4:13], TimeUnit.seconds, 60
             # HHMMSS
             case _, _, _, _, _, _:
-                yield segment[0:2], TimeUnit.HOURS, 24
-                yield segment[2:4], TimeUnit.MINUTES, 60
-                yield segment[4:6], TimeUnit.SECONDS, 60
+                yield segment[0:2], TimeUnit.hours, 24
+                yield segment[2:4], TimeUnit.minutes, 60
+                yield segment[4:6], TimeUnit.seconds, 60
             case _:
                 raise ValueError(f"unable to parse '{segment}' into time components")
 
@@ -118,7 +118,7 @@ class timedelta(datetime.timedelta):
                 pass
 
             while unit := next(context, None):
-                if unit.name == char:
+                if unit == char:
                     break
             else:
                 raise ValueError(f"unexpected character '{char}'")
@@ -165,10 +165,10 @@ class timedelta(datetime.timedelta):
                 msg = f"unable to parse '{value}' as a positive decimal"
                 raise ValueError(msg) from exc
             if quantity:
-                yield unit, quantity
+                yield unit.name, quantity
             if limit and (quantity > limit if inclusive_limit else quantity >= limit):
                 bounds = f"[0..{limit}" + ("]" if inclusive_limit else ")")
-                raise ValueError(f"{unit} value of {value} exceeds range {bounds}")
+                raise ValueError(f"{unit.name} value of {value} exceeds range {bounds}")
 
     @classmethod
     def fromisoformat(cls, duration: str) -> "timedelta":

--- a/src/timedelta_isoformat/__init__.py
+++ b/src/timedelta_isoformat/__init__.py
@@ -2,6 +2,8 @@
 import datetime
 from typing import Iterable, Tuple, TypeAlias
 
+_DECIMAL_CHARACTERS = frozenset("0123456789" + ",.")
+
 
 class timedelta(datetime.timedelta):
     """Subclass of :py:class:`datetime.timedelta` with additional methods to implement
@@ -85,17 +87,11 @@ class timedelta(datetime.timedelta):
         date_context = iter((("Y", "years"), ("M", "months"), ("D", "days")))
         time_context = iter((("H", "hours"), ("M", "minutes"), ("S", "seconds")))
         week_context = iter((("W", "weeks"),))
-        decimal_points = {",", "."}
 
         context, value, unit = date_context, "", None
         for char in duration:
-            if char.isdigit():
+            if char in _DECIMAL_CHARACTERS:
                 value += char
-                continue
-
-            if char in decimal_points:
-                value += "."
-                decimal_points.clear()
                 continue
 
             if char == "T" and context is date_context:
@@ -149,7 +145,7 @@ class timedelta(datetime.timedelta):
         for value, unit, limit in components:
             try:
                 assert value[0].isdigit()
-                quantity = float(value)
+                quantity = float(value.replace(",", "."))
             except (AssertionError, IndexError, ValueError) as exc:
                 msg = f"unable to parse '{value}' as a positive decimal"
                 raise ValueError(msg) from exc

--- a/src/timedelta_isoformat/__init__.py
+++ b/src/timedelta_isoformat/__init__.py
@@ -103,7 +103,7 @@ class timedelta(datetime.timedelta):
         week_context = iter(WeekUnit)
 
         context, value = date_context, ""
-        weeks_visited, values_found = False, 0
+        values_found = 0
         for char in duration:
             if char in _DECIMAL_CHARACTERS:
                 value += char
@@ -116,7 +116,6 @@ class timedelta(datetime.timedelta):
 
             if char == "W" and context is date_context:
                 context = week_context
-                weeks_visited = True
                 pass
 
             for unit in context:
@@ -130,7 +129,7 @@ class timedelta(datetime.timedelta):
             values_found += 1
 
         assert values_found, "no measurements found"
-        assert not weeks_visited or values_found == 1, "cannot mix weeks with other units"
+        assert tuple(week_context) or values_found == 1, "cannot mix weeks with other units"
 
     @classmethod
     def _from_duration(cls, duration: str) -> Measurements:

--- a/src/timedelta_isoformat/__init__.py
+++ b/src/timedelta_isoformat/__init__.py
@@ -15,7 +15,7 @@ Components: TypeAlias = Iterable[Tuple[UnparsedValue, TimedeltaArgument, ValueLi
 Measurements: TypeAlias = Iterable[Tuple[TimedeltaArgument, float]]
 
 class ParsingContext:
-    remaining_tokens: Iterable[Token]
+    unparsed_valid_tokens: Iterable[Token]
     token_to_timedelta_arg: Dict[Token, TimedeltaArgument]
 
     def __init__(
@@ -23,7 +23,7 @@ class ParsingContext:
         token_to_timedelta_arg: Dict[Token, TimedeltaArgument],
     ):
         self.token_to_timedelta_arg = token_to_timedelta_arg
-        self.remaining_tokens = iter(token_to_timedelta_arg)
+        self.unparsed_valid_tokens = iter(token_to_timedelta_arg)
 
 class timedelta(datetime.timedelta):
     """Subclass of :py:class:`datetime.timedelta` with additional methods to implement
@@ -137,14 +137,14 @@ class timedelta(datetime.timedelta):
                 pass
 
             # Note: this advances and may exhaust the token iterator
-            if char not in context.remaining_tokens:
+            if char not in context.unparsed_valid_tokens:
                 raise ValueError(f"unexpected character '{char}'")
 
             yield value, context.token_to_timedelta_arg[char], None
             value = ""
 
-        weeks_parsed = next(week_context.remaining_tokens, None) != "W"
-        time_parsed = next(time_context.remaining_tokens, None) != "H" or next(date_context.remaining_tokens, None) != "Y"
+        weeks_parsed = next(week_context.unparsed_valid_tokens, None) != "W"
+        time_parsed = next(time_context.unparsed_valid_tokens, None) != "H" or next(date_context.unparsed_valid_tokens, None) != "Y"
         assert weeks_parsed or time_parsed, "no measurements found"
         assert weeks_parsed != time_parsed, "cannot mix weeks with other units"
 

--- a/src/timedelta_isoformat/__init__.py
+++ b/src/timedelta_isoformat/__init__.py
@@ -110,7 +110,7 @@ class timedelta(datetime.timedelta):
 
             if char == "T" and context is not time_context:
                 assert not value, f"expected a unit designator after '{value}'"
-                context = time_context
+                context, value = time_context, ""
                 continue
 
             if char == "W" and context is date_context:

--- a/src/timedelta_isoformat/__init__.py
+++ b/src/timedelta_isoformat/__init__.py
@@ -111,7 +111,6 @@ class timedelta(datetime.timedelta):
             else:
                 raise ValueError(f"unexpected character '{char}'")
 
-
         assert unit, "no measurements found"
 
     @classmethod

--- a/src/timedelta_isoformat/__init__.py
+++ b/src/timedelta_isoformat/__init__.py
@@ -99,9 +99,7 @@ class timedelta(datetime.timedelta):
                 value += "."
                 continue
 
-            if char == "T":
-                assert context is not time_context, f"unexpected character '{char}' after previous time components"
-                assert context is not week_context, "cannot mix weeks with other units"
+            if char == "T" and context is date_context:
                 assert not value, f"missing unit designator after '{value}'"
                 context = time_context
                 continue

--- a/src/timedelta_isoformat/__init__.py
+++ b/src/timedelta_isoformat/__init__.py
@@ -39,7 +39,6 @@ class timedelta(datetime.timedelta):
             raise ValueError(f"{self.unit} value of {self.value} exceeds range {bounds}")
 
     Components: TypeAlias = Iterable[Component]
-    Measurements: TypeAlias = Iterable[Tuple[str, float]]
 
     def __repr__(self) -> str:
         return f"timedelta_isoformat.{super().__repr__()}"
@@ -143,7 +142,7 @@ class timedelta(datetime.timedelta):
         assert unit, "no measurements found"
 
     @classmethod
-    def _parse_duration(cls, duration: str) -> Measurements:
+    def _parse_duration(cls, duration: str) -> Components:
         """Selects and runs an appropriate parser for ISO-8601 duration strings
 
         The format of these strings is composed of two segments; date measurements

--- a/src/timedelta_isoformat/__init__.py
+++ b/src/timedelta_isoformat/__init__.py
@@ -149,11 +149,12 @@ class timedelta(datetime.timedelta):
             except (AssertionError, IndexError, ValueError) as exc:
                 msg = f"unable to parse '{value}' as a positive decimal"
                 raise ValueError(msg) from exc
+            if not quantity:
+                continue
             if limit and (quantity > limit if inclusive_limit else quantity >= limit):
                 bounds = f"[0..{limit}" + ("]" if inclusive_limit else ")")
                 raise ValueError(f"{unit} value of {value} exceeds range {bounds}")
-            if quantity:
-                yield unit, quantity
+            yield unit, quantity
 
     @classmethod
     def fromisoformat(cls, duration: str) -> "timedelta":

--- a/src/timedelta_isoformat/__init__.py
+++ b/src/timedelta_isoformat/__init__.py
@@ -84,7 +84,7 @@ class timedelta(datetime.timedelta):
         time_context = {"S": "seconds", "M": "minutes", "H": "hours"}
         week_context = {"W": "weeks"}
 
-        context, value, values_found = date_context, "", False
+        tokens_consumed, context, value = 0, date_context, ""
         for char in duration:
             if char in _DECIMAL_CHARACTERS:
                 value += char
@@ -107,11 +107,12 @@ class timedelta(datetime.timedelta):
             except KeyError:
                 raise ValueError(f"unexpected character '{char}'")
 
-            assert week_context or not values_found, "cannot mix weeks with other units"
+            tokens_consumed += 1
             yield value, unit, None
-            value, values_found = "", True
+            value = ""
 
-        assert values_found, "no measurements found"
+        assert tokens_consumed, "no measurements found"
+        assert week_context or tokens_consumed == 1, "cannot mix weeks with other units"
 
     @classmethod
     def _from_duration(cls, duration: str) -> Measurements:

--- a/src/timedelta_isoformat/__init__.py
+++ b/src/timedelta_isoformat/__init__.py
@@ -2,7 +2,8 @@
 import datetime
 from typing import Iterable, Tuple, TypeAlias
 
-_NUMERIC_CHARACTERS = frozenset("0123456789" + ",.")
+_DIGITS, _DECIMAL_SIGNS = frozenset("0123456789"), frozenset(",.")
+_FORMAT = _DIGITS | _DECIMAL_SIGNS
 
 
 class timedelta(datetime.timedelta):
@@ -90,7 +91,7 @@ class timedelta(datetime.timedelta):
 
         tokens, value = date_tokens, ""
         for char in duration:
-            if char in _NUMERIC_CHARACTERS:
+            if char in _FORMAT:
                 value += char
                 continue
 

--- a/src/timedelta_isoformat/__init__.py
+++ b/src/timedelta_isoformat/__init__.py
@@ -94,31 +94,35 @@ class timedelta(datetime.timedelta):
         in order of largest-to-smallest unit from left-to-right (with the exception of
         week measurements, which must be the only measurement in the string if present).
         """
-        contexts_encountered, context, remaining_tokens, value = set(), DateContext, iter(DateContext), ""
+        date_tokens = iter(DateContext)
+        time_tokens = iter(TimeContext)
+        week_tokens = iter(WeekContext)
+
+        context, remaining_tokens, value = DateContext, date_tokens, ""
         for char in duration:
             if char in _DECIMAL_CHARACTERS:
                 value += char
                 continue
 
             if char == "T" and context is not TimeContext:
-                context, remaining_tokens, value = TimeContext, iter(TimeContext), ""
+                context, remaining_tokens, value = TimeContext, time_tokens, ""
                 continue
 
             if char == "W" and context is DateContext:
-                context, remaining_tokens = WeekContext, iter(WeekContext)
+                context, remaining_tokens = WeekContext, week_tokens
                 pass
 
-            try:
-                while (unit := next(remaining_tokens)) != char: continue
-            except StopIteration:
+            # Note: this advances and may exhaust the token iterator
+            if char not in remaining_tokens:
                 raise ValueError(f"unexpected character '{char}'")
 
-            contexts_encountered.add(context)
-            yield value, unit.name.lower(), None
+            yield value, context(char).name.lower(), None
             value = ""
 
-        assert contexts_encountered, "no measurements found"
-        assert WeekContext not in contexts_encountered or len(contexts_encountered) == 1, "cannot mix weeks with other units"
+        weeks_parsed = next(week_tokens, None) != WeekContext.WEEKS
+        time_parsed = next(time_tokens, None) != TimeContext.HOURS or next(date_tokens, None) != DateContext.YEARS
+        assert weeks_parsed or time_parsed, "no measurements found"
+        assert weeks_parsed != time_parsed, "cannot mix weeks with other units"
 
     @classmethod
     def _from_duration(cls, duration: str) -> Measurements:

--- a/src/timedelta_isoformat/__init__.py
+++ b/src/timedelta_isoformat/__init__.py
@@ -84,31 +84,31 @@ class timedelta(datetime.timedelta):
         in order of largest-to-smallest unit from left-to-right (with the exception of
         week measurements, which must be the only measurement in the string if present).
         """
-        date_tokens = iter(("Y", "years", "M", "months", "D", "days"))
-        time_tokens = iter(("H", "hours", "M", "minutes", "S", "seconds"))
-        week_tokens = iter(("W", "weeks"))
+        date_context = iter(("Y", "years", "M", "months", "D", "days"))
+        time_context = iter(("H", "hours", "M", "minutes", "S", "seconds"))
+        week_context = iter(("W", "weeks"))
 
-        tokens, value, unit = date_tokens, "", None
+        context, value, unit = date_context, "", None
         for char in duration:
             if char in _DECIMAL_CHARACTERS:
                 value += char
                 continue
 
-            if char == "T" and tokens is date_tokens:
+            if char == "T" and context is date_context:
                 assert not value, f"expected a unit designator after '{value}'"
-                tokens = time_tokens
+                context = time_context
                 continue
 
-            if char == "W" and tokens is date_tokens:
-                tokens = week_tokens
+            if char == "W" and context is date_context:
+                context = week_context
                 pass
 
             # Note: this advances and may exhaust the token iterator
-            assert not (unit and tokens is week_tokens), "cannot mix weeks with other units"
-            if char not in tokens:
+            assert not (unit and context is week_context), "cannot mix weeks with other units"
+            if char not in context:
                 raise ValueError(f"unexpected character '{char}'")
 
-            unit = next(tokens)
+            unit = next(context)
             yield value, unit, None
             value = ""
 

--- a/src/timedelta_isoformat/__init__.py
+++ b/src/timedelta_isoformat/__init__.py
@@ -33,9 +33,10 @@ class timedelta(datetime.timedelta):
                 case None, _ if 0 <= self.quantity: return True
                 case _, True if 0 <= self.quantity <= self.limit: return True
                 case _, False if 0 <= self.quantity < self.limit: return True
-
-            bounds = f"[0..{self.limit}" + ("]" if inclusive_limit else ")")
-            raise ValueError(f"{self.unit} value of {self.value} exceeds range {bounds}")
+                case _:
+                    bounds = f"[0..{self.limit}" + ("]" if inclusive_limit else ")")
+                    msg = f"{self.unit} value of {self.value} exceeds range {bounds}"
+                    raise ValueError(msg)
 
     Components: TypeAlias = Iterable[Component]
 

--- a/src/timedelta_isoformat/__init__.py
+++ b/src/timedelta_isoformat/__init__.py
@@ -10,7 +10,7 @@ class timedelta(datetime.timedelta):
     ISO8601-style parsing and formatting.
     """
 
-    Components: TypeAlias = Iterable[Tuple[str, str, int]]
+    Components: TypeAlias = Iterable[Tuple[str, str, int | None]]
     Measurements: TypeAlias = Iterable[Tuple[str, float]]
 
     def __repr__(self) -> str:
@@ -22,23 +22,23 @@ class timedelta(datetime.timedelta):
 
             # YYYY-DDD
             case _, _, _, _, "-", _, _, _:
-                yield segment[0:4], "years", 9999
+                yield segment[0:4], "years", None
                 yield segment[5:8], "days", 366
 
             # YYYY-MM-DD
             case _, _, _, _, "-", _, _, "-", _, _:
-                yield segment[0:4], "years", 9999
+                yield segment[0:4], "years", None
                 yield segment[5:7], "months", 12
                 yield segment[8:10], "days", 31
 
             # YYYYDDD
             case _, _, _, _, _, _, _:
-                yield segment[0:4], "years", 9999
+                yield segment[0:4], "years", None
                 yield segment[4:7], "days", 366
 
             # YYYYMMDD
             case _, _, _, _, _, _, _, _:
-                yield segment[0:4], "years", 9999
+                yield segment[0:4], "years", None
                 yield segment[4:6], "months", 12
                 yield segment[6:8], "days", 31
 

--- a/src/timedelta_isoformat/__init__.py
+++ b/src/timedelta_isoformat/__init__.py
@@ -2,8 +2,7 @@
 import datetime
 from typing import Iterable, Tuple, TypeAlias
 
-_DIGITS, _DECIMAL_SIGNS = frozenset("0123456789"), frozenset(",.")
-_FORMAT = _DIGITS | _DECIMAL_SIGNS
+_NUMERIC_CHARACTERS = frozenset("0123456789" + ",.")
 
 
 class timedelta(datetime.timedelta):
@@ -91,7 +90,7 @@ class timedelta(datetime.timedelta):
 
         tokens, value, unit = date_tokens, "", None
         for char in duration:
-            if char in _FORMAT:
+            if char in _NUMERIC_CHARACTERS:
                 value += char
                 continue
 

--- a/src/timedelta_isoformat/__init__.py
+++ b/src/timedelta_isoformat/__init__.py
@@ -25,16 +25,17 @@ class timedelta(datetime.timedelta):
             except (AssertionError, IndexError, ValueError) as exc:
                 msg = f"unable to parse '{self.value}' as a positive decimal"
                 raise ValueError(msg) from exc
+            try:
+                assert self.valid
+            except:
+                raise
 
         @property
         def valid(self) -> bool:
-            if not self.quantity: return False
             if not self.limit: return True
-
             inclusive_limit = self.limit not in (24, 60)
             if inclusive_limit and 0 <= self.quantity <= self.limit: return True
             if not inclusive_limit and 0 <= self.quantity < self.limit: return True
-
             bounds = f"[0..{self.limit}" + ("]" if inclusive_limit else ")")
             raise ValueError(f"{self.unit} value of {self.value} exceeds range {bounds}")
 
@@ -171,7 +172,7 @@ class timedelta(datetime.timedelta):
         :raises: `ValueError` with an explanatory message when parsing fails
         """
         try:
-            return cls(**{m.unit: m.quantity for m in cls._parse_duration(duration) if m.valid})
+            return cls(**{m.unit: m.quantity for m in cls._parse_duration(duration) if m.quantity})
         except (AssertionError, ValueError) as exc:
             raise ValueError(f"could not parse duration '{duration}': {exc}") from exc
 

--- a/src/timedelta_isoformat/__init__.py
+++ b/src/timedelta_isoformat/__init__.py
@@ -108,9 +108,8 @@ class timedelta(datetime.timedelta):
                 unit = next(context)
                 yield value, unit, None
                 value = ""
-                continue
-
-            raise ValueError(f"unexpected character '{char}'")
+            else:
+                raise ValueError(f"unexpected character '{char}'")
 
 
         assert unit, "no measurements found"

--- a/src/timedelta_isoformat/__init__.py
+++ b/src/timedelta_isoformat/__init__.py
@@ -1,30 +1,12 @@
 """Supplemental ISO8601 duration format support for :py:class:`datetime.timedelta`"""
 import datetime
-from enum import StrEnum
 from typing import Iterable, Tuple, TypeAlias
 from dataclasses import dataclass
 
 _DECIMAL_CHARACTERS = frozenset("0123456789" + ",.")
 
-
-class DateUnit(StrEnum):
-    Y = "years"
-    M = "months"
-    D = "days"
-
-
-class TimeUnit(StrEnum):
-    H = "hours"
-    M = "minutes"
-    S = "seconds"
-
-
-class WeekUnit(StrEnum):
-    W = "weeks"
-
-
 RawValue: TypeAlias = str
-Unit: TypeAlias = DateUnit | TimeUnit | WeekUnit
+Unit: TypeAlias = str
 MeasurementLimit: TypeAlias = int | None
 MeasuredValue: TypeAlias = float
 
@@ -45,22 +27,22 @@ class timedelta(datetime.timedelta):
         match tuple(segment):
             # YYYY-DDD
             case _, _, _, _, "-", _, _, _:
-                yield segment[0:4], DateUnit.Y, None
-                yield segment[5:8], DateUnit.D, 366
+                yield segment[0:4], "years", None
+                yield segment[5:8], "days", 366
             # YYYY-MM-DD
             case _, _, _, _, "-", _, _, "-", _, _:
-                yield segment[0:4], DateUnit.Y, None
-                yield segment[5:7], DateUnit.M, 12
-                yield segment[8:10], DateUnit.D, 31
+                yield segment[0:4], "years", None
+                yield segment[5:7], "months", 12
+                yield segment[8:10], "days", 31
             # YYYYDDD
             case _, _, _, _, _, _, _:
-                yield segment[0:4], DateUnit.Y, None
-                yield segment[4:7], DateUnit.D, 366
+                yield segment[0:4], "years", None
+                yield segment[4:7], "days", 366
             # YYYYMMDD
             case _, _, _, _, _, _, _, _:
-                yield segment[0:4], DateUnit.Y, None
-                yield segment[4:6], DateUnit.M, 12
-                yield segment[6:8], DateUnit.D, 31
+                yield segment[0:4], "years", None
+                yield segment[4:6], "months", 12
+                yield segment[6:8], "days", 31
             case _:
                 raise ValueError(f"unable to parse '{segment}' into date components")
 
@@ -69,24 +51,24 @@ class timedelta(datetime.timedelta):
         match tuple(segment):
             # HH:MM:SS[.ssssss]
             case _, _, ":", _, _, ":", _, _, ".", *_:
-                yield segment[0:2], TimeUnit.H, 24
-                yield segment[3:5], TimeUnit.M, 60
-                yield segment[6:15], TimeUnit.S, 60
+                yield segment[0:2], "hours", 24
+                yield segment[3:5], "minutes", 60
+                yield segment[6:15], "seconds", 60
             # HH:MM:SS
             case _, _, ":", _, _, ":", _, _:
-                yield segment[0:2], TimeUnit.H, 24
-                yield segment[3:5], TimeUnit.M, 60
-                yield segment[6:8], TimeUnit.S, 60
+                yield segment[0:2], "hours", 24
+                yield segment[3:5], "minutes", 60
+                yield segment[6:8], "seconds", 60
             # HHMMSS[.ssssss]
             case _, _, _, _, _, _, ".", *_:
-                yield segment[0:2], TimeUnit.H, 24
-                yield segment[2:4], TimeUnit.M, 60
-                yield segment[4:13], TimeUnit.S, 60
+                yield segment[0:2], "hours", 24
+                yield segment[2:4], "minutes", 60
+                yield segment[4:13], "seconds", 60
             # HHMMSS
             case _, _, _, _, _, _:
-                yield segment[0:2], TimeUnit.H, 24
-                yield segment[2:4], TimeUnit.M, 60
-                yield segment[4:6], TimeUnit.S, 60
+                yield segment[0:2], "hours", 24
+                yield segment[2:4], "minutes", 60
+                yield segment[4:6], "seconds", 60
             case _:
                 raise ValueError(f"unable to parse '{segment}' into time components")
 

--- a/src/timedelta_isoformat/__init__.py
+++ b/src/timedelta_isoformat/__init__.py
@@ -155,7 +155,7 @@ class timedelta(datetime.timedelta):
                 raise ValueError(msg) from exc
             if not quantity:
                 continue
-            if limit and (quantity > limit if inclusive_limit else quantity >= limit):
+            if limit and not (0 <= quantity <= limit if inclusive_limit else 0 <= quantity < limit):
                 bounds = f"[0..{limit}" + ("]" if inclusive_limit else ")")
                 raise ValueError(f"{unit} value of {value} exceeds range {bounds}")
             yield unit, quantity

--- a/src/timedelta_isoformat/__init__.py
+++ b/src/timedelta_isoformat/__init__.py
@@ -103,7 +103,7 @@ class timedelta(datetime.timedelta):
         week_context = iter(WeekUnit)
 
         context, value = date_context, ""
-        values_found = 0
+        weeks_visited, values_found = False, 0
         for char in duration:
             if char in _DECIMAL_CHARACTERS:
                 value += char
@@ -116,6 +116,7 @@ class timedelta(datetime.timedelta):
 
             if char == "W" and context is date_context:
                 context = week_context
+                weeks_visited = True
                 pass
 
             for unit in context:
@@ -129,7 +130,7 @@ class timedelta(datetime.timedelta):
             values_found += 1
 
         assert values_found, "no measurements found"
-        assert tuple(week_context) or values_found == 1, "cannot mix weeks with other units"
+        assert not weeks_visited or values_found == 1, "cannot mix weeks with other units"
 
     @classmethod
     def _from_duration(cls, duration: str) -> Measurements:

--- a/src/timedelta_isoformat/__init__.py
+++ b/src/timedelta_isoformat/__init__.py
@@ -29,8 +29,7 @@ class timedelta(datetime.timedelta):
 
         def _bounds_check(self) -> bool:
             if not self.limit:
-                if 0 <= self.quantity:
-                    return True
+                return True
 
             inclusive_limit = self.limit not in (24, 60)
             if inclusive_limit:

--- a/src/timedelta_isoformat/__init__.py
+++ b/src/timedelta_isoformat/__init__.py
@@ -88,21 +88,21 @@ class timedelta(datetime.timedelta):
         time_context = iter((("H", "hours"), ("M", "minutes"), ("S", "seconds")))
         week_context = iter((("W", "weeks"),))
 
-        context, head, tail, unit = date_context, "", "", None
+        context, value, unit = date_context, "", None
         for char in duration:
             if char.isdigit():
-                tail += char
+                value += char
                 continue
 
             if char in _DECIMAL_POINTS:
-                assert not head, f"unexpected character '{char}'"
-                head, tail = tail, "."
+                assert value.isdigit(), f"unexpected character '{char}'"
+                value += "."
                 continue
 
             if char == "T":
                 assert context is not time_context, f"unexpected character '{char}'"
                 assert context is not week_context, "cannot mix weeks with other units"
-                assert not head + tail, f"missing unit designator after '{head + tail}'"
+                assert not value, f"missing unit designator after '{value}'"
                 context = time_context
                 continue
 
@@ -113,8 +113,8 @@ class timedelta(datetime.timedelta):
             assert not (context is week_context and unit), "cannot mix weeks with other units"
             for delimiter, unit in context:
                 if char == delimiter:
-                    yield head + tail, unit, None
-                    head = tail = ""
+                    yield value, unit, None
+                    value = ""
                     break
             else:
                 raise ValueError(f"unexpected character '{char}'")

--- a/src/timedelta_isoformat/__init__.py
+++ b/src/timedelta_isoformat/__init__.py
@@ -99,11 +99,12 @@ class timedelta(datetime.timedelta):
                 context = week_context
                 pass
 
-            while context:
-                designator, unit = context.popitem()
-                if designator == char:
-                    break
-            else:
+            try:
+                while item := context.popitem():
+                    designator, unit = item
+                    if designator == char:
+                        break
+            except KeyError:
                 raise ValueError(f"unexpected character '{char}'")
 
             assert week_context or not values_found, "cannot mix weeks with other units"

--- a/src/timedelta_isoformat/__init__.py
+++ b/src/timedelta_isoformat/__init__.py
@@ -95,7 +95,6 @@ class timedelta(datetime.timedelta):
                 continue
 
             if char in _DECIMAL_POINTS:
-                assert value.isdigit(), f"unexpected character '{char}' after decimal '{value}'"
                 value += "."
                 continue
 

--- a/src/timedelta_isoformat/__init__.py
+++ b/src/timedelta_isoformat/__init__.py
@@ -1,6 +1,7 @@
 """Supplemental ISO8601 duration format support for :py:class:`datetime.timedelta`"""
 import datetime
 from enum import StrEnum
+from itertools import chain
 from typing import Iterable, Tuple, TypeAlias, Dict
 from dataclasses import dataclass
 

--- a/src/timedelta_isoformat/__init__.py
+++ b/src/timedelta_isoformat/__init__.py
@@ -118,8 +118,11 @@ class timedelta(datetime.timedelta):
                 pass
 
             assert not (unit and context is week_context), "cannot mix weeks with other units"
-            unit = next(filter(char.__eq__, context), None)
-            assert unit, f"unexpected character '{char}'"
+            for unit in context:
+                if unit == char:
+                    break
+            else:
+                raise ValueError(f"unexpected character '{char}'")
 
             yield value, unit, None
             value = ""

--- a/src/timedelta_isoformat/__init__.py
+++ b/src/timedelta_isoformat/__init__.py
@@ -29,8 +29,7 @@ class timedelta(datetime.timedelta):
 
         def _bounds_check(self) -> bool:
             if not self.limit:
-                if 0 <= self.quantity:
-                    return True
+                return 0 <= self.quantity
 
             inclusive_limit = self.limit not in (24, 60)
             if inclusive_limit:

--- a/src/timedelta_isoformat/__init__.py
+++ b/src/timedelta_isoformat/__init__.py
@@ -151,7 +151,7 @@ class timedelta(datetime.timedelta):
                 raise ValueError(msg) from exc
             if quantity:
                 yield unit, quantity
-            if limit and not (0 <= quantity <= limit if inclusive_limit else 0 <= quantity < limit):
+            if limit and (quantity > limit if inclusive_limit else quantity >= limit):
                 bounds = f"[0..{limit}" + ("]" if inclusive_limit else ")")
                 raise ValueError(f"{unit} value of {value} exceeds range {bounds}")
 

--- a/src/timedelta_isoformat/__init__.py
+++ b/src/timedelta_isoformat/__init__.py
@@ -28,18 +28,13 @@ class timedelta(datetime.timedelta):
                 raise ValueError(msg) from exc
 
         def _bounds_check(self) -> bool:
-            if not self.limit:
-                return True
+            upper_limit_inclusive = self.limit not in (24, 60) if self.limit else None
+            match upper_limit_inclusive:
+                case None if 0 <= self.quantity: return True
+                case True if 0 <= self.quantity <= self.limit: return True
+                case False if 0 <= self.quantity < self.limit: return True
 
-            inclusive_limit = self.limit not in (24, 60)
-            if inclusive_limit:
-                if 0 <= self.quantity <= self.limit:
-                    return True
-            else:
-                if 0 <= self.quantity < self.limit:
-                    return True
-
-            bounds = f"[0..{self.limit}" + ("]" if inclusive_limit else ")")
+            bounds = f"[0..{self.limit}" + ("]" if upper_limit_inclusive else ")")
             raise ValueError(f"{self.unit} value of {self.value} exceeds range {bounds}")
 
     Components: TypeAlias = Iterable[Component]

--- a/src/timedelta_isoformat/__init__.py
+++ b/src/timedelta_isoformat/__init__.py
@@ -2,7 +2,7 @@
 import datetime
 from typing import Iterable, Tuple, TypeAlias
 
-_DECIMAL_POINTS = frozenset(",.")
+_NUMBER_FORMAT = frozenset("0123456789,.")
 
 
 class timedelta(datetime.timedelta):
@@ -90,12 +90,8 @@ class timedelta(datetime.timedelta):
 
         context, value, unit = date_context, "", None
         for char in duration:
-            if char.isdigit():
-                value += char
-                continue
-
-            if char in _DECIMAL_POINTS:
-                value += "."
+            if char in _NUMBER_FORMAT:
+                value += char if char.isdigit() else "."
                 continue
 
             if char == "T" and context is date_context:

--- a/src/timedelta_isoformat/__init__.py
+++ b/src/timedelta_isoformat/__init__.py
@@ -22,13 +22,10 @@ class timedelta(datetime.timedelta):
             try:
                 assert self.value[0].isdigit()
                 self.quantity = float(self.value)
-            except (AssertionError, IndexError, ValueError) as exc:
+                assert self.valid
+            except (AssertionError, IndexError) as exc:
                 msg = f"unable to parse '{self.value}' as a positive decimal"
                 raise ValueError(msg) from exc
-            try:
-                assert self.valid
-            except:
-                raise
 
         @property
         def valid(self) -> bool:

--- a/src/timedelta_isoformat/__init__.py
+++ b/src/timedelta_isoformat/__init__.py
@@ -23,20 +23,24 @@ class timedelta(datetime.timedelta):
             case _, _, _, _, "-", _, _, _:
                 yield segment[0:4], "years", None
                 yield segment[5:8], "days", 366
+
             # YYYY-MM-DD
             case _, _, _, _, "-", _, _, "-", _, _:
                 yield segment[0:4], "years", None
                 yield segment[5:7], "months", 12
                 yield segment[8:10], "days", 31
+
             # YYYYDDD
             case _, _, _, _, _, _, _:
                 yield segment[0:4], "years", None
                 yield segment[4:7], "days", 366
+
             # YYYYMMDD
             case _, _, _, _, _, _, _, _:
                 yield segment[0:4], "years", None
                 yield segment[4:6], "months", 12
                 yield segment[6:8], "days", 31
+
             case _:
                 raise ValueError(f"unable to parse '{segment}' into date components")
 
@@ -48,21 +52,25 @@ class timedelta(datetime.timedelta):
                 yield segment[0:2], "hours", 24
                 yield segment[3:5], "minutes", 60
                 yield segment[6:15], "seconds", 60
+
             # HH:MM:SS
             case _, _, ":", _, _, ":", _, _:
                 yield segment[0:2], "hours", 24
                 yield segment[3:5], "minutes", 60
                 yield segment[6:8], "seconds", 60
+
             # HHMMSS[.ssssss]
             case _, _, _, _, _, _, ".", *_:
                 yield segment[0:2], "hours", 24
                 yield segment[2:4], "minutes", 60
                 yield segment[4:13], "seconds", 60
+
             # HHMMSS
             case _, _, _, _, _, _:
                 yield segment[0:2], "hours", 24
                 yield segment[2:4], "minutes", 60
                 yield segment[4:6], "seconds", 60
+
             case _:
                 raise ValueError(f"unable to parse '{segment}' into time components")
 

--- a/src/timedelta_isoformat/__init__.py
+++ b/src/timedelta_isoformat/__init__.py
@@ -96,7 +96,7 @@ class timedelta(datetime.timedelta):
 
             if char == "T" and tokens is date_tokens:
                 assert not value, f"expected a unit designator after '{value}'"
-                tokens, value = time_tokens, ""
+                tokens = time_tokens
                 continue
 
             if char == "W" and tokens is date_tokens:

--- a/src/timedelta_isoformat/__init__.py
+++ b/src/timedelta_isoformat/__init__.py
@@ -2,8 +2,6 @@
 import datetime
 from typing import Iterable, Tuple, TypeAlias
 
-_DECIMAL_CHARACTERS = frozenset("0123456789" + ",.")
-
 
 class timedelta(datetime.timedelta):
     """Subclass of :py:class:`datetime.timedelta` with additional methods to implement
@@ -87,11 +85,17 @@ class timedelta(datetime.timedelta):
         date_context = iter((("Y", "years"), ("M", "months"), ("D", "days")))
         time_context = iter((("H", "hours"), ("M", "minutes"), ("S", "seconds")))
         week_context = iter((("W", "weeks"),))
+        decimal_points = {",", "."}
 
         context, value, unit = date_context, "", None
         for char in duration:
-            if char in _DECIMAL_CHARACTERS:
+            if char.isdigit():
                 value += char
+                continue
+
+            if char in decimal_points:
+                value += "."
+                decimal_points.clear()
                 continue
 
             if char == "T" and context is date_context:
@@ -145,7 +149,7 @@ class timedelta(datetime.timedelta):
         for value, unit, limit in components:
             try:
                 assert value[0].isdigit()
-                quantity = float(value.replace(",", "."))
+                quantity = float(value)
             except (AssertionError, IndexError, ValueError) as exc:
                 msg = f"unable to parse '{value}' as a positive decimal"
                 raise ValueError(msg) from exc

--- a/src/timedelta_isoformat/__init__.py
+++ b/src/timedelta_isoformat/__init__.py
@@ -19,13 +19,9 @@ class timedelta(datetime.timedelta):
         quantity: float = 0
 
         def __post_init__(self) -> None:
-            try:
-                assert self.value[0].isdigit()
-                self.quantity = float(self.value)
-                assert self._bounds_check()
-            except (AssertionError, IndexError) as exc:
-                msg = f"unable to parse '{self.value}' as a positive decimal"
-                raise ValueError(msg) from exc
+            assert self.value[0:1].isdigit(), f"unable to parse '{self.value}' as a positive decimal"
+            self.quantity = float(self.value)
+            assert self._bounds_check()
 
         def _bounds_check(self) -> bool:
             inclusive_limit = self.limit not in (24, 60)

--- a/src/timedelta_isoformat/__init__.py
+++ b/src/timedelta_isoformat/__init__.py
@@ -1,4 +1,5 @@
 """Supplemental ISO8601 duration format support for :py:class:`datetime.timedelta`"""
+from dataclasses import dataclass
 import datetime
 from typing import Iterable, Tuple, TypeAlias
 
@@ -10,7 +11,16 @@ class timedelta(datetime.timedelta):
     ISO8601-style parsing and formatting.
     """
 
-    Components: TypeAlias = Iterable[Tuple[str, str, int | None]]
+    @dataclass
+    class Component:
+        value: str
+        unit: str
+        limit: int | None = None
+
+        def __iter__(self):
+            return iter((self.value, self.unit, self.limit))
+
+    Components: TypeAlias = Iterable[Component]
     Measurements: TypeAlias = Iterable[Tuple[str, float]]
 
     def __repr__(self) -> str:
@@ -22,25 +32,25 @@ class timedelta(datetime.timedelta):
 
             # YYYY-DDD
             case _, _, _, _, "-", _, _, _:
-                yield segment[0:4], "years", None
-                yield segment[5:8], "days", 366
+                yield timedelta.Component(segment[0:4], "years")
+                yield timedelta.Component(segment[5:8], "days", 366)
 
             # YYYY-MM-DD
             case _, _, _, _, "-", _, _, "-", _, _:
-                yield segment[0:4], "years", None
-                yield segment[5:7], "months", 12
-                yield segment[8:10], "days", 31
+                yield timedelta.Component(segment[0:4], "years")
+                yield timedelta.Component(segment[5:7], "months", 12)
+                yield timedelta.Component(segment[8:10], "days", 31)
 
             # YYYYDDD
             case _, _, _, _, _, _, _:
-                yield segment[0:4], "years", None
-                yield segment[4:7], "days", 366
+                yield timedelta.Component(segment[0:4], "years")
+                yield timedelta.Component(segment[4:7], "days", 366)
 
             # YYYYMMDD
             case _, _, _, _, _, _, _, _:
-                yield segment[0:4], "years", None
-                yield segment[4:6], "months", 12
-                yield segment[6:8], "days", 31
+                yield timedelta.Component(segment[0:4], "years")
+                yield timedelta.Component(segment[4:6], "months", 12)
+                yield timedelta.Component(segment[6:8], "days", 31)
 
             case _:
                 raise ValueError(f"unable to parse '{segment}' into date components")
@@ -51,27 +61,27 @@ class timedelta(datetime.timedelta):
 
             # HH:MM:SS[.ssssss]
             case _, _, ":", _, _, ":", _, _, ".", *_:
-                yield segment[0:2], "hours", 24
-                yield segment[3:5], "minutes", 60
-                yield segment[6:15], "seconds", 60
+                yield timedelta.Component(segment[0:2], "hours", 24)
+                yield timedelta.Component(segment[3:5], "minutes", 60)
+                yield timedelta.Component(segment[6:15], "seconds", 60)
 
             # HH:MM:SS
             case _, _, ":", _, _, ":", _, _:
-                yield segment[0:2], "hours", 24
-                yield segment[3:5], "minutes", 60
-                yield segment[6:8], "seconds", 60
+                yield timedelta.Component(segment[0:2], "hours", 24)
+                yield timedelta.Component(segment[3:5], "minutes", 60)
+                yield timedelta.Component(segment[6:8], "seconds", 60)
 
             # HHMMSS[.ssssss]
             case _, _, _, _, _, _, ".", *_:
-                yield segment[0:2], "hours", 24
-                yield segment[2:4], "minutes", 60
-                yield segment[4:13], "seconds", 60
+                yield timedelta.Component(segment[0:2], "hours", 24)
+                yield timedelta.Component(segment[2:4], "minutes", 60)
+                yield timedelta.Component(segment[4:13], "seconds", 60)
 
             # HHMMSS
             case _, _, _, _, _, _:
-                yield segment[0:2], "hours", 24
-                yield segment[2:4], "minutes", 60
-                yield segment[4:6], "seconds", 60
+                yield timedelta.Component(segment[0:2], "hours", 24)
+                yield timedelta.Component(segment[2:4], "minutes", 60)
+                yield timedelta.Component(segment[4:6], "seconds", 60)
 
             case _:
                 raise ValueError(f"unable to parse '{segment}' into time components")
@@ -106,7 +116,7 @@ class timedelta(datetime.timedelta):
             assert not (context is week_context and unit), "cannot mix weeks with other units"
             for delimiter, unit in context:
                 if char == delimiter:
-                    yield value, unit, None
+                    yield timedelta.Component(value, unit)
                     value = ""
                     break
             else:
@@ -128,20 +138,17 @@ class timedelta(datetime.timedelta):
         assert duration.startswith("P"), "durations must begin with the character 'P'"
 
         if duration[-1].isupper():
-            components = cls._from_designators(duration[1:])
-            yield from cls._to_measurements(components, inclusive_limit=True)
+            yield from cls._to_measurements(cls._from_designators(duration[1:]))
             return
 
         date_segment, _, time_segment = duration[1:].partition("T")
         if date_segment:
-            components = cls._from_date(date_segment)
-            yield from cls._to_measurements(components, inclusive_limit=True)
+            yield from cls._to_measurements(cls._from_date(date_segment))
         if time_segment:
-            components = cls._from_time(time_segment)
-            yield from cls._to_measurements(components, inclusive_limit=False)
+            yield from cls._to_measurements(cls._from_time(time_segment))
 
     @staticmethod
-    def _to_measurements(components: Components, inclusive_limit: bool) -> Measurements:
+    def _to_measurements(components: Components) -> Measurements:
         for value, unit, limit in components:
             try:
                 assert value[0].isdigit()
@@ -151,6 +158,7 @@ class timedelta(datetime.timedelta):
                 raise ValueError(msg) from exc
             if not quantity:
                 continue
+            inclusive_limit = limit not in (24, 60)
             if limit and not (0 <= quantity <= limit if inclusive_limit else 0 <= quantity < limit):
                 bounds = f"[0..{limit}" + ("]" if inclusive_limit else ")")
                 raise ValueError(f"{unit} value of {value} exceeds range {bounds}")

--- a/src/timedelta_isoformat/__init__.py
+++ b/src/timedelta_isoformat/__init__.py
@@ -102,8 +102,7 @@ class timedelta(datetime.timedelta):
         time_context = iter(TimeUnit)
         week_context = iter(WeekUnit)
 
-        context, value = date_context, ""
-        values_found = 0
+        context, value, values_found = date_context, "", 0
         for char in duration:
             if char in _DECIMAL_CHARACTERS:
                 value += char

--- a/src/timedelta_isoformat/__init__.py
+++ b/src/timedelta_isoformat/__init__.py
@@ -94,8 +94,8 @@ class timedelta(datetime.timedelta):
                 continue
 
             if char in decimal_points:
-                value += "."
                 decimal_points.clear()
+                value += "."
                 continue
 
             if char == "T" and context is date_context:

--- a/src/timedelta_isoformat/__init__.py
+++ b/src/timedelta_isoformat/__init__.py
@@ -149,11 +149,11 @@ class timedelta(datetime.timedelta):
             except (AssertionError, IndexError, ValueError) as exc:
                 msg = f"unable to parse '{value}' as a positive decimal"
                 raise ValueError(msg) from exc
-            if quantity:
-                yield unit, quantity
             if limit and (quantity > limit if inclusive_limit else quantity >= limit):
                 bounds = f"[0..{limit}" + ("]" if inclusive_limit else ")")
                 raise ValueError(f"{unit} value of {value} exceeds range {bounds}")
+            if quantity:
+                yield unit, quantity
 
     @classmethod
     def fromisoformat(cls, duration: str) -> "timedelta":

--- a/src/timedelta_isoformat/__init__.py
+++ b/src/timedelta_isoformat/__init__.py
@@ -8,19 +8,19 @@ _DECIMAL_CHARACTERS = frozenset("0123456789" + ",.")
 
 
 class DateUnit(StrEnum):
-    Y = YEARS = "years"
-    M = MONTHS = "months"
-    D = DAYS = "days"
+    Y = "years"
+    M = "months"
+    D = "days"
 
 
 class TimeUnit(StrEnum):
-    H = HOURS = "hours"
-    M = MINUTES = "minutes"
-    S = SECONDS = "seconds"
+    H = "hours"
+    M = "minutes"
+    S = "seconds"
 
 
 class WeekUnit(StrEnum):
-    W = WEEKS = "weeks"
+    W = "weeks"
 
 
 RawValue: TypeAlias = str
@@ -45,22 +45,22 @@ class timedelta(datetime.timedelta):
         match tuple(segment):
             # YYYY-DDD
             case _, _, _, _, "-", _, _, _:
-                yield segment[0:4], DateUnit.YEARS, None
-                yield segment[5:8], DateUnit.DAYS, 366
+                yield segment[0:4], DateUnit.Y, None
+                yield segment[5:8], DateUnit.D, 366
             # YYYY-MM-DD
             case _, _, _, _, "-", _, _, "-", _, _:
-                yield segment[0:4], DateUnit.YEARS, None
-                yield segment[5:7], DateUnit.MONTHS, 12
-                yield segment[8:10], DateUnit.DAYS, 31
+                yield segment[0:4], DateUnit.Y, None
+                yield segment[5:7], DateUnit.M, 12
+                yield segment[8:10], DateUnit.D, 31
             # YYYYDDD
             case _, _, _, _, _, _, _:
-                yield segment[0:4], DateUnit.YEARS, None
-                yield segment[4:7], DateUnit.DAYS, 366
+                yield segment[0:4], DateUnit.Y, None
+                yield segment[4:7], DateUnit.D, 366
             # YYYYMMDD
             case _, _, _, _, _, _, _, _:
-                yield segment[0:4], DateUnit.YEARS, None
-                yield segment[4:6], DateUnit.MONTHS, 12
-                yield segment[6:8], DateUnit.DAYS, 31
+                yield segment[0:4], DateUnit.Y, None
+                yield segment[4:6], DateUnit.M, 12
+                yield segment[6:8], DateUnit.D, 31
             case _:
                 raise ValueError(f"unable to parse '{segment}' into date components")
 
@@ -69,24 +69,24 @@ class timedelta(datetime.timedelta):
         match tuple(segment):
             # HH:MM:SS[.ssssss]
             case _, _, ":", _, _, ":", _, _, ".", *_:
-                yield segment[0:2], TimeUnit.HOURS, 24
-                yield segment[3:5], TimeUnit.MINUTES, 60
-                yield segment[6:15], TimeUnit.SECONDS, 60
+                yield segment[0:2], TimeUnit.H, 24
+                yield segment[3:5], TimeUnit.M, 60
+                yield segment[6:15], TimeUnit.S, 60
             # HH:MM:SS
             case _, _, ":", _, _, ":", _, _:
-                yield segment[0:2], TimeUnit.HOURS, 24
-                yield segment[3:5], TimeUnit.MINUTES, 60
-                yield segment[6:8], TimeUnit.SECONDS, 60
+                yield segment[0:2], TimeUnit.H, 24
+                yield segment[3:5], TimeUnit.M, 60
+                yield segment[6:8], TimeUnit.S, 60
             # HHMMSS[.ssssss]
             case _, _, _, _, _, _, ".", *_:
-                yield segment[0:2], TimeUnit.HOURS, 24
-                yield segment[2:4], TimeUnit.MINUTES, 60
-                yield segment[4:13], TimeUnit.SECONDS, 60
+                yield segment[0:2], TimeUnit.H, 24
+                yield segment[2:4], TimeUnit.M, 60
+                yield segment[4:13], TimeUnit.S, 60
             # HHMMSS
             case _, _, _, _, _, _:
-                yield segment[0:2], TimeUnit.HOURS, 24
-                yield segment[2:4], TimeUnit.MINUTES, 60
-                yield segment[4:6], TimeUnit.SECONDS, 60
+                yield segment[0:2], TimeUnit.H, 24
+                yield segment[2:4], TimeUnit.M, 60
+                yield segment[4:6], TimeUnit.S, 60
             case _:
                 raise ValueError(f"unable to parse '{segment}' into time components")
 

--- a/src/timedelta_isoformat/__init__.py
+++ b/src/timedelta_isoformat/__init__.py
@@ -111,7 +111,7 @@ class timedelta(datetime.timedelta):
 
             if char == "T" and context is not time_context:
                 assert not value, f"expected a unit designator after '{value}'"
-                context = time_context
+                context, value = time_context, ""
                 continue
 
             if char == "W" and context is date_context:

--- a/src/timedelta_isoformat/__init__.py
+++ b/src/timedelta_isoformat/__init__.py
@@ -84,9 +84,9 @@ class timedelta(datetime.timedelta):
         in order of largest-to-smallest unit from left-to-right (with the exception of
         week measurements, which must be the only measurement in the string if present).
         """
-        date_context = iter(("Y", "years", "M", "months", "D", "days"))
-        time_context = iter(("H", "hours", "M", "minutes", "S", "seconds"))
-        week_context = iter(("W", "weeks"))
+        date_context = iter((("Y", "years"), ("M", "months"), ("D", "days")))
+        time_context = iter((("H", "hours"), ("M", "minutes"), ("S", "seconds")))
+        week_context = iter((("W", "weeks"),))
 
         context, value, unit = date_context, "", None
         for char in duration:
@@ -104,10 +104,11 @@ class timedelta(datetime.timedelta):
                 pass
 
             assert not (unit and context is week_context), "cannot mix weeks with other units"
-            if char in context:
-                unit = next(context)
-                yield value, unit, None
-                value = ""
+            for delimiter, unit in context:
+                if delimiter == char:
+                    yield value, unit, None
+                    value = ""
+                    break
             else:
                 raise ValueError(f"unexpected character '{char}'")
 

--- a/src/timedelta_isoformat/__init__.py
+++ b/src/timedelta_isoformat/__init__.py
@@ -95,7 +95,7 @@ class timedelta(datetime.timedelta):
                 continue
 
             if char in _DECIMAL_POINTS:
-                assert value.isdigit(), f"unexpected character '{char}'"
+                assert value.isdigit(), f"unexpected character '{char}' after decimal '{value}'"
                 value += "."
                 continue
 

--- a/src/timedelta_isoformat/__init__.py
+++ b/src/timedelta_isoformat/__init__.py
@@ -106,7 +106,7 @@ class timedelta(datetime.timedelta):
 
             if char == "T" and context is not time_context:
                 assert not value, f"expected a unit designator after '{value}'"
-                context = time_context
+                context, value = time_context, ""
                 continue
 
             if char == "W" and context is date_context:

--- a/src/timedelta_isoformat/__init__.py
+++ b/src/timedelta_isoformat/__init__.py
@@ -16,9 +16,27 @@ class timedelta(datetime.timedelta):
         value: str
         unit: str
         limit: int | None = None
+        quantity: float = 0
 
-        def __iter__(self):
-            return iter((self.value, self.unit, self.limit))
+        def __post_init__(self):
+            try:
+                assert self.value[0].isdigit()
+                self.quantity = float(self.value)
+            except (AssertionError, IndexError, ValueError) as exc:
+                msg = f"unable to parse '{self.value}' as a positive decimal"
+                raise ValueError(msg) from exc
+
+        @property
+        def valid(self):
+            if not self.quantity: return False
+            if not self.limit: return True
+
+            inclusive_limit = self.limit not in (24, 60)
+            if inclusive_limit and 0 <= self.quantity <= self.limit: return True
+            if not inclusive_limit and 0 <= self.quantity < self.limit: return True
+
+            bounds = f"[0..{self.limit}" + ("]" if inclusive_limit else ")")
+            raise ValueError(f"{self.unit} value of {self.value} exceeds range {bounds}")
 
     Components: TypeAlias = Iterable[Component]
     Measurements: TypeAlias = Iterable[Tuple[str, float]]
@@ -138,31 +156,14 @@ class timedelta(datetime.timedelta):
         assert duration.startswith("P"), "durations must begin with the character 'P'"
 
         if duration[-1].isupper():
-            yield from cls._to_measurements(cls._from_designators(duration[1:]))
+            yield from cls._from_designators(duration[1:])
             return
 
         date_segment, _, time_segment = duration[1:].partition("T")
         if date_segment:
-            yield from cls._to_measurements(cls._from_date(date_segment))
+            yield from cls._from_date(date_segment)
         if time_segment:
-            yield from cls._to_measurements(cls._from_time(time_segment))
-
-    @staticmethod
-    def _to_measurements(components: Components) -> Measurements:
-        for value, unit, limit in components:
-            try:
-                assert value[0].isdigit()
-                quantity = float(value)
-            except (AssertionError, IndexError, ValueError) as exc:
-                msg = f"unable to parse '{value}' as a positive decimal"
-                raise ValueError(msg) from exc
-            if not quantity:
-                continue
-            inclusive_limit = limit not in (24, 60)
-            if limit and not (0 <= quantity <= limit if inclusive_limit else 0 <= quantity < limit):
-                bounds = f"[0..{limit}" + ("]" if inclusive_limit else ")")
-                raise ValueError(f"{unit} value of {value} exceeds range {bounds}")
-            yield unit, quantity
+            yield from cls._from_time(time_segment)
 
     @classmethod
     def fromisoformat(cls, duration: str) -> "timedelta":
@@ -171,7 +172,7 @@ class timedelta(datetime.timedelta):
         :raises: `ValueError` with an explanatory message when parsing fails
         """
         try:
-            return cls(**dict(cls._from_duration(duration)))
+            return cls(**{m.unit: m.quantity for m in cls._from_duration(duration) if m.valid})
         except (AssertionError, ValueError) as exc:
             raise ValueError(f"could not parse duration '{duration}': {exc}") from exc
 

--- a/src/timedelta_isoformat/__init__.py
+++ b/src/timedelta_isoformat/__init__.py
@@ -28,13 +28,13 @@ class timedelta(datetime.timedelta):
                 raise ValueError(msg) from exc
 
         def _bounds_check(self) -> bool:
-            inclusive_limit = self.limit not in (24, 60)
-            match self.limit, inclusive_limit:
-                case None, _ if 0 <= self.quantity: return True
-                case _, True if 0 <= self.quantity <= self.limit: return True
-                case _, False if 0 <= self.quantity < self.limit: return True
+            upper_limit_inclusive = self.limit not in (24, 60) if self.limit else None
+            match upper_limit_inclusive:
+                case None if 0 <= self.quantity: return True
+                case True if 0 <= self.quantity <= self.limit: return True
+                case False if 0 <= self.quantity < self.limit: return True
 
-            bounds = f"[0..{self.limit}" + ("]" if inclusive_limit else ")")
+            bounds = f"[0..{self.limit}" + ("]" if upper_limit_inclusive else ")")
             raise ValueError(f"{self.unit} value of {self.value} exceeds range {bounds}")
 
     Components: TypeAlias = Iterable[Component]

--- a/src/timedelta_isoformat/__init__.py
+++ b/src/timedelta_isoformat/__init__.py
@@ -29,7 +29,8 @@ class timedelta(datetime.timedelta):
 
         def _bounds_check(self) -> bool:
             if not self.limit:
-                return 0 <= self.quantity
+                if 0 <= self.quantity:
+                    return True
 
             inclusive_limit = self.limit not in (24, 60)
             if inclusive_limit:

--- a/src/timedelta_isoformat/__init__.py
+++ b/src/timedelta_isoformat/__init__.py
@@ -1,18 +1,18 @@
 """Supplemental ISO8601 duration format support for :py:class:`datetime.timedelta`"""
 import datetime
 from enum import StrEnum
-from typing import Iterable, Tuple, TypeAlias
+from typing import Iterable, Tuple, TypeAlias, Dict
 from dataclasses import dataclass
 
 _DECIMAL_CHARACTERS = frozenset("0123456789" + ",.")
 
-RawValue: TypeAlias = str
-Unit: TypeAlias = str
-MeasurementLimit: TypeAlias = int | None
-MeasuredValue: TypeAlias = float
 
-Components: TypeAlias = Iterable[Tuple[RawValue, Unit, MeasurementLimit]]
-Measurements: TypeAlias = Iterable[Tuple[Unit, MeasuredValue]]
+Token: TypeAlias = str
+Unit: TypeAlias = str
+UnparsedValue: TypeAlias = str
+ValueLimit: TypeAlias = int | None
+Components: TypeAlias = Iterable[Tuple[UnparsedValue, Unit, ValueLimit]]
+Measurements: TypeAlias = Iterable[Tuple[Unit, float]]
 
 class DateContext(StrEnum):
     YEARS = "Y"

--- a/src/timedelta_isoformat/__init__.py
+++ b/src/timedelta_isoformat/__init__.py
@@ -145,13 +145,13 @@ class timedelta(datetime.timedelta):
         for value, unit, limit in components:
             try:
                 assert value[0].isdigit()
-                quantity = float("+" + value.replace(",", "."))
+                quantity = float(value.replace(",", "."))
             except (AssertionError, IndexError, ValueError) as exc:
                 msg = f"unable to parse '{value}' as a positive decimal"
                 raise ValueError(msg) from exc
             if quantity:
                 yield unit, quantity
-            if limit and (quantity > limit if inclusive_limit else quantity >= limit):
+            if limit and not (0 <= quantity <= limit if inclusive_limit else 0 <= quantity < limit):
                 bounds = f"[0..{limit}" + ("]" if inclusive_limit else ")")
                 raise ValueError(f"{unit} value of {value} exceeds range {bounds}")
 

--- a/src/timedelta_isoformat/__init__.py
+++ b/src/timedelta_isoformat/__init__.py
@@ -118,11 +118,8 @@ class timedelta(datetime.timedelta):
                 pass
 
             assert not (unit and context is week_context), "cannot mix weeks with other units"
-            for unit in context:
-                if unit == char:
-                    break
-            else:
-                raise ValueError(f"unexpected character '{char}'")
+            unit = next(filter(char.__eq__, context), None)
+            assert unit, f"unexpected character '{char}'"
 
             yield value, unit, None
             value = ""

--- a/src/timedelta_isoformat/__init__.py
+++ b/src/timedelta_isoformat/__init__.py
@@ -26,68 +26,68 @@ class timedelta(datetime.timedelta):
     def __repr__(self) -> str:
         return f"timedelta_isoformat.{super().__repr__()}"
 
-    @staticmethod
-    def _from_date(segment: str) -> Components:
+    @classmethod
+    def _from_date(cls, segment: str) -> Components:
         match tuple(segment):
 
             # YYYY-DDD
             case _, _, _, _, "-", _, _, _:
-                yield timedelta.Component(segment[0:4], "years")
-                yield timedelta.Component(segment[5:8], "days", 366)
+                yield cls.Component(segment[0:4], "years")
+                yield cls.Component(segment[5:8], "days", 366)
 
             # YYYY-MM-DD
             case _, _, _, _, "-", _, _, "-", _, _:
-                yield timedelta.Component(segment[0:4], "years")
-                yield timedelta.Component(segment[5:7], "months", 12)
-                yield timedelta.Component(segment[8:10], "days", 31)
+                yield cls.Component(segment[0:4], "years")
+                yield cls.Component(segment[5:7], "months", 12)
+                yield cls.Component(segment[8:10], "days", 31)
 
             # YYYYDDD
             case _, _, _, _, _, _, _:
-                yield timedelta.Component(segment[0:4], "years")
-                yield timedelta.Component(segment[4:7], "days", 366)
+                yield cls.Component(segment[0:4], "years")
+                yield cls.Component(segment[4:7], "days", 366)
 
             # YYYYMMDD
             case _, _, _, _, _, _, _, _:
-                yield timedelta.Component(segment[0:4], "years")
-                yield timedelta.Component(segment[4:6], "months", 12)
-                yield timedelta.Component(segment[6:8], "days", 31)
+                yield cls.Component(segment[0:4], "years")
+                yield cls.Component(segment[4:6], "months", 12)
+                yield cls.Component(segment[6:8], "days", 31)
 
             case _:
                 raise ValueError(f"unable to parse '{segment}' into date components")
 
-    @staticmethod
-    def _from_time(segment: str) -> Components:
+    @classmethod
+    def _from_time(cls, segment: str) -> Components:
         match tuple(segment):
 
             # HH:MM:SS[.ssssss]
             case _, _, ":", _, _, ":", _, _, ".", *_:
-                yield timedelta.Component(segment[0:2], "hours", 24)
-                yield timedelta.Component(segment[3:5], "minutes", 60)
-                yield timedelta.Component(segment[6:15], "seconds", 60)
+                yield cls.Component(segment[0:2], "hours", 24)
+                yield cls.Component(segment[3:5], "minutes", 60)
+                yield cls.Component(segment[6:15], "seconds", 60)
 
             # HH:MM:SS
             case _, _, ":", _, _, ":", _, _:
-                yield timedelta.Component(segment[0:2], "hours", 24)
-                yield timedelta.Component(segment[3:5], "minutes", 60)
-                yield timedelta.Component(segment[6:8], "seconds", 60)
+                yield cls.Component(segment[0:2], "hours", 24)
+                yield cls.Component(segment[3:5], "minutes", 60)
+                yield cls.Component(segment[6:8], "seconds", 60)
 
             # HHMMSS[.ssssss]
             case _, _, _, _, _, _, ".", *_:
-                yield timedelta.Component(segment[0:2], "hours", 24)
-                yield timedelta.Component(segment[2:4], "minutes", 60)
-                yield timedelta.Component(segment[4:13], "seconds", 60)
+                yield cls.Component(segment[0:2], "hours", 24)
+                yield cls.Component(segment[2:4], "minutes", 60)
+                yield cls.Component(segment[4:13], "seconds", 60)
 
             # HHMMSS
             case _, _, _, _, _, _:
-                yield timedelta.Component(segment[0:2], "hours", 24)
-                yield timedelta.Component(segment[2:4], "minutes", 60)
-                yield timedelta.Component(segment[4:6], "seconds", 60)
+                yield cls.Component(segment[0:2], "hours", 24)
+                yield cls.Component(segment[2:4], "minutes", 60)
+                yield cls.Component(segment[4:6], "seconds", 60)
 
             case _:
                 raise ValueError(f"unable to parse '{segment}' into time components")
 
-    @staticmethod
-    def _from_designators(duration: str) -> Components:
+    @classmethod
+    def _from_designators(cls, duration: str) -> Components:
         """Parser for designator-separated ISO-8601 duration strings
 
         The code sweeps through the input exactly once, expecting to find measurements
@@ -116,7 +116,7 @@ class timedelta(datetime.timedelta):
             assert not (context is week_context and unit), "cannot mix weeks with other units"
             for delimiter, unit in context:
                 if char == delimiter:
-                    yield timedelta.Component(value, unit)
+                    yield cls.Component(value, unit)
                     value = ""
                     break
             else:

--- a/src/timedelta_isoformat/__init__.py
+++ b/src/timedelta_isoformat/__init__.py
@@ -110,7 +110,7 @@ class timedelta(datetime.timedelta):
 
             if char == "T" and context is not TimeUnit:
                 assert not value, f"expected a unit designator after '{value}'"
-                context, remaining_tokens, value = TimeUnit, time_context, ""
+                context, remaining_tokens = TimeUnit, time_context
                 continue
 
             if char == "W" and context is DateUnit:

--- a/src/timedelta_isoformat/__init__.py
+++ b/src/timedelta_isoformat/__init__.py
@@ -98,9 +98,9 @@ class timedelta(datetime.timedelta):
         in order of largest-to-smallest unit from left-to-right (with the exception of
         week measurements, which must be the only measurement in the string if present).
         """
-        date_context = iter((DateUnit.years, DateUnit.months, DateUnit.days))
-        time_context = iter((TimeUnit.hours, TimeUnit.minutes, TimeUnit.seconds))
-        week_context = iter((WeekUnit.weeks,))
+        date_context = [DateUnit.days, DateUnit.months, DateUnit.years]
+        time_context = [TimeUnit.seconds, TimeUnit.minutes, TimeUnit.hours]
+        week_context = [WeekUnit.weeks]
 
         context, value, unit = date_context, "", None
         for char in duration:
@@ -118,8 +118,11 @@ class timedelta(datetime.timedelta):
                 pass
 
             assert not (unit and context is week_context), "cannot mix weeks with other units"
-            unit = next(filter(char.__eq__, context), None)
-            assert unit, f"unexpected character '{char}'"
+            try:
+                while (unit := context.pop()) != char:
+                    continue
+            except IndexError:
+                raise ValueError(f"unexpected character '{char}'")
 
             yield value, unit, None
             value = ""

--- a/src/timedelta_isoformat/__init__.py
+++ b/src/timedelta_isoformat/__init__.py
@@ -121,7 +121,8 @@ class timedelta(datetime.timedelta):
                 raise ValueError(f"unexpected character '{char}'")
 
             yield value, context(char), None
-            value, values_found = "", values_found + 1
+            value = ""
+            values_found += 1
 
         assert values_found, "no measurements found"
         assert next(week_context, None) or values_found == 1, "cannot mix weeks with other units"

--- a/src/timedelta_isoformat/__init__.py
+++ b/src/timedelta_isoformat/__init__.py
@@ -95,6 +95,7 @@ class timedelta(datetime.timedelta):
                 continue
 
             if char == "T" and tokens is date_tokens:
+                assert not value, f"expected a unit designator after '{value}'"
                 tokens, value = time_tokens, ""
                 continue
 

--- a/src/timedelta_isoformat/__init__.py
+++ b/src/timedelta_isoformat/__init__.py
@@ -80,11 +80,11 @@ class timedelta(datetime.timedelta):
         in order of largest-to-smallest unit from left-to-right (with the exception of
         week measurements, which must be the only measurement in the string if present).
         """
-        date_context = {"D": "days", "M": "months", "Y": "years"}
-        time_context = {"S": "seconds", "M": "minutes", "H": "hours"}
-        week_context = {"W": "weeks"}
+        date_context = iter({"Y": "years", "M": "months", "D": "days"}.items())
+        time_context = iter({"H": "hours", "M": "minutes", "S": "seconds"}.items())
+        week_context = iter({"W": "weeks"}.items())
 
-        tokens_consumed, context, value = 0, date_context, ""
+        contexts_encountered, context, value = set(), date_context, ""
         for char in duration:
             if char in _DECIMAL_CHARACTERS:
                 value += char
@@ -99,20 +99,18 @@ class timedelta(datetime.timedelta):
                 context = week_context
                 pass
 
-            try:
-                while item := context.popitem():
-                    designator, unit = item
-                    if designator == char:
-                        tokens_consumed += 1
-                        break
-            except KeyError:
+            for designator, unit in context:
+                if designator == char:
+                    break
+            else:
                 raise ValueError(f"unexpected character '{char}'")
 
+            contexts_encountered.add(context)
             yield value, unit, None
             value = ""
 
-        assert tokens_consumed, "no measurements found"
-        assert week_context or tokens_consumed == 1, "cannot mix weeks with other units"
+        assert contexts_encountered, "no measurements found"
+        assert week_context not in contexts_encountered or len(contexts_encountered) == 1, "cannot mix weeks with other units"
 
     @classmethod
     def _from_duration(cls, duration: str) -> Measurements:

--- a/src/timedelta_isoformat/__init__.py
+++ b/src/timedelta_isoformat/__init__.py
@@ -98,8 +98,11 @@ class timedelta(datetime.timedelta):
         in order of largest-to-smallest unit from left-to-right (with the exception of
         week measurements, which must be the only measurement in the string if present).
         """
-        context, remaining_tokens, value = DateUnit, iter(DateUnit), ""
-        weeks_visited, values_found = False, 0
+        date_context = iter(DateUnit)
+        time_context = iter(TimeUnit)
+        week_context = iter(WeekUnit)
+
+        context, remaining_tokens, value, values_found = DateUnit, date_context, "", 0
         for char in duration:
             if char in _DECIMAL_CHARACTERS:
                 value += char
@@ -107,12 +110,11 @@ class timedelta(datetime.timedelta):
 
             if char == "T" and context is not TimeUnit:
                 assert not value, f"expected a unit designator after '{value}'"
-                context, remaining_tokens, value = TimeUnit, iter(TimeUnit), ""
+                context, remaining_tokens, value = TimeUnit, time_context, ""
                 continue
 
             if char == "W" and context is DateUnit:
-                context, remaining_tokens = WeekUnit, iter(WeekUnit)
-                weeks_visited = True
+                context, remaining_tokens = WeekUnit, week_context
                 pass
 
             if char not in remaining_tokens:
@@ -123,7 +125,7 @@ class timedelta(datetime.timedelta):
             values_found += 1
 
         assert values_found, "no measurements found"
-        assert not weeks_visited or values_found == 1, "cannot mix weeks with other units"
+        assert next(week_context, None) or values_found == 1, "cannot mix weeks with other units"
 
     @classmethod
     def _from_duration(cls, duration: str) -> Measurements:

--- a/src/timedelta_isoformat/__init__.py
+++ b/src/timedelta_isoformat/__init__.py
@@ -13,6 +13,22 @@ MeasuredValue: TypeAlias = float
 Components: TypeAlias = Iterable[Tuple[RawValue, Unit, MeasurementLimit]]
 Measurements: TypeAlias = Iterable[Tuple[Unit, MeasuredValue]]
 
+DateContext = {
+    "Y": "years",
+    "M": "months",
+    "D": "days",
+}
+
+TimeContext = {
+    "H": "hours",
+    "M": "minutes",
+    "S": "seconds",
+}
+
+WeekContext = {
+    "W": "weeks",
+}
+
 
 class timedelta(datetime.timedelta):
     """Subclass of :py:class:`datetime.timedelta` with additional methods to implement
@@ -80,9 +96,9 @@ class timedelta(datetime.timedelta):
         in order of largest-to-smallest unit from left-to-right (with the exception of
         week measurements, which must be the only measurement in the string if present).
         """
-        date_context = iter({"Y": "years", "M": "months", "D": "days"}.items())
-        time_context = iter({"H": "hours", "M": "minutes", "S": "seconds"}.items())
-        week_context = iter({"W": "weeks"}.items())
+        date_context = iter(DateContext.items())
+        time_context = iter(TimeContext.items())
+        week_context = iter(WeekContext.items())
 
         contexts_encountered, context, value = set(), date_context, ""
         for char in duration:

--- a/src/timedelta_isoformat/__init__.py
+++ b/src/timedelta_isoformat/__init__.py
@@ -26,7 +26,7 @@ class DateComponent:
     unit: str
     limit: int | None = None
     quantity: float = 0
-    unit_type: type = DateUnit
+    unit_type: TypeAlias = DateUnit
 
     def __post_init__(self) -> None:
         try:
@@ -50,7 +50,7 @@ class DateComponent:
 @dataclass
 class TimeComponent(DateComponent):
     limit: int
-    unit_type: type = TimeUnit
+    unit_type: TypeAlias = TimeUnit
 
 
 class timedelta(datetime.timedelta):

--- a/src/timedelta_isoformat/__init__.py
+++ b/src/timedelta_isoformat/__init__.py
@@ -22,6 +22,8 @@ class DateComponent:
         except (AssertionError, IndexError, ValueError) as exc:
             msg = f"unable to parse '{value}' as a positive decimal"
             raise ValueError(msg) from exc
+        if not quantity:
+            return
         if limit and not (0 <= quantity <= limit if inclusive_limit else 0 <= quantity < limit):
             bounds = f"[0..{limit}" + ("]" if inclusive_limit else ")")
             raise ValueError(f"{unit} value of {value} exceeds range {bounds}")

--- a/src/timedelta_isoformat/__init__.py
+++ b/src/timedelta_isoformat/__init__.py
@@ -156,14 +156,13 @@ class timedelta(datetime.timedelta):
                 pass
 
             assert not (unit and context is week_context), "cannot mix weeks with other units"
-            for delimiter in context:
-                if char == delimiter:
-                    unit = char
-                    yield (TimeComponent if context is time_context else DateComponent)(head + tail, unit)
-                    head = tail = ""
-                    break
-            else:
+
+            # Note: this advances and may exhaust the context iterator
+            if char not in context:
                 raise ValueError(f"unexpected character '{char}'")
+
+            yield (TimeComponent if context is time_context else DateComponent)(head + tail, char)
+            head, tail, unit = "", "", char
 
         assert unit, "no measurements found"
 

--- a/src/timedelta_isoformat/__init__.py
+++ b/src/timedelta_isoformat/__init__.py
@@ -11,6 +11,26 @@ class DateComponent:
     value: str
     unit: str
     limit: int | None = None
+    quantity: float = 0
+
+    def __post_init__(self):
+        value, unit, limit = self.value, self.unit, self.limit
+        inclusive_limit = not isinstance(self, TimeComponent)
+        try:
+            assert value[0].isdigit()
+            quantity = float(value)
+        except (AssertionError, IndexError, ValueError) as exc:
+            msg = f"unable to parse '{value}' as a positive decimal"
+            raise ValueError(msg) from exc
+        if not quantity:
+            return
+        if limit and not (0 <= quantity <= limit if inclusive_limit else 0 <= quantity < limit):
+            bounds = f"[0..{limit}" + ("]" if inclusive_limit else ")")
+            raise ValueError(f"{unit} value of {value} exceeds range {bounds}")
+        self.quantity = quantity
+
+    def astuple(self):
+        return self.unit, self.quantity
 
 
 @dataclass
@@ -146,35 +166,20 @@ class timedelta(datetime.timedelta):
         assert duration.startswith("P"), "durations must begin with the character 'P'"
 
         if duration[-1].isupper():
-            components = cls._from_designators(duration[1:])
-            yield from cls._to_measurements(components)
+            for component in cls._from_designators(duration[1:]):
+                if component.quantity:
+                    yield component.astuple()
             return
 
         date_segment, _, time_segment = duration[1:].partition("T")
         if date_segment:
-            components = cls._from_date(date_segment)
-            yield from cls._to_measurements(components)
+            for component in cls._from_date(date_segment):
+                if component.quantity:
+                    yield component.astuple()
         if time_segment:
-            components = cls._from_time(time_segment)
-            yield from cls._to_measurements(components)
-
-    @staticmethod
-    def _to_measurements(components: Components) -> Measurements:
-        for component in components:
-            value, unit, limit = component.value, component.unit, component.limit
-            inclusive_limit = not isinstance(component, TimeComponent)
-            try:
-                assert value[0].isdigit()
-                quantity = float(value)
-            except (AssertionError, IndexError, ValueError) as exc:
-                msg = f"unable to parse '{value}' as a positive decimal"
-                raise ValueError(msg) from exc
-            if not quantity:
-                continue
-            if limit and not (0 <= quantity <= limit if inclusive_limit else 0 <= quantity < limit):
-                bounds = f"[0..{limit}" + ("]" if inclusive_limit else ")")
-                raise ValueError(f"{unit} value of {value} exceeds range {bounds}")
-            yield unit, quantity
+            for component in cls._from_time(time_segment):
+                if component.quantity:
+                    yield component.astuple()
 
     @classmethod
     def fromisoformat(cls, duration: str) -> "timedelta":

--- a/src/timedelta_isoformat/__init__.py
+++ b/src/timedelta_isoformat/__init__.py
@@ -26,7 +26,7 @@ class DateComponent:
     unit: str
     limit: int | None = None
     quantity: float = 0
-    unit_type: TypeAlias = DateUnit
+    unit_type: type = DateUnit
 
     def __post_init__(self) -> None:
         try:
@@ -50,7 +50,7 @@ class DateComponent:
 @dataclass
 class TimeComponent(DateComponent):
     limit: int
-    unit_type: TypeAlias = TimeUnit
+    unit_type: type = TimeUnit
 
 
 class timedelta(datetime.timedelta):

--- a/src/timedelta_isoformat/__init__.py
+++ b/src/timedelta_isoformat/__init__.py
@@ -1,9 +1,23 @@
 """Supplemental ISO8601 duration format support for :py:class:`datetime.timedelta`"""
 from dataclasses import dataclass
 import datetime
+from enum import StrEnum
 from typing import Iterable, Tuple, TypeAlias
 
 _NUMBER_FORMAT = frozenset("0123456789,.")
+
+class DateUnit(StrEnum):
+    years = "Y"
+    months = "M"
+    days = "D"
+
+class TimeUnit(StrEnum):
+    hours = "H"
+    minutes = "M"
+    seconds = "S"
+
+class WeekUnit(StrEnum):
+    weeks = "W"
 
 
 class timedelta(datetime.timedelta):
@@ -36,7 +50,7 @@ class timedelta(datetime.timedelta):
             if not inclusive_limit and 0 <= self.quantity < self.limit: return True
 
             bounds = f"[0..{self.limit}" + ("]" if inclusive_limit else ")")
-            raise ValueError(f"{self.unit} value of {self.value} exceeds range {bounds}")
+            raise ValueError(f"{self.unit.name} value of {self.value} exceeds range {bounds}")
 
     Components: TypeAlias = Iterable[Component]
     Measurements: TypeAlias = Iterable[Tuple[str, float]]
@@ -50,25 +64,25 @@ class timedelta(datetime.timedelta):
 
             # YYYY-DDD
             case _, _, _, _, "-", _, _, _:
-                yield cls.Component(segment[0:4], "years")
-                yield cls.Component(segment[5:8], "days", 366)
+                yield cls.Component(segment[0:4], DateUnit.years)
+                yield cls.Component(segment[5:8], DateUnit.days, 366)
 
             # YYYY-MM-DD
             case _, _, _, _, "-", _, _, "-", _, _:
-                yield cls.Component(segment[0:4], "years")
-                yield cls.Component(segment[5:7], "months", 12)
-                yield cls.Component(segment[8:10], "days", 31)
+                yield cls.Component(segment[0:4], DateUnit.years)
+                yield cls.Component(segment[5:7], DateUnit.months, 12)
+                yield cls.Component(segment[8:10], DateUnit.days, 31)
 
             # YYYYDDD
             case _, _, _, _, _, _, _:
-                yield cls.Component(segment[0:4], "years")
-                yield cls.Component(segment[4:7], "days", 366)
+                yield cls.Component(segment[0:4], DateUnit.years)
+                yield cls.Component(segment[4:7], DateUnit.days, 366)
 
             # YYYYMMDD
             case _, _, _, _, _, _, _, _:
-                yield cls.Component(segment[0:4], "years")
-                yield cls.Component(segment[4:6], "months", 12)
-                yield cls.Component(segment[6:8], "days", 31)
+                yield cls.Component(segment[0:4], DateUnit.years)
+                yield cls.Component(segment[4:6], DateUnit.months, 12)
+                yield cls.Component(segment[6:8], DateUnit.days, 31)
 
             case _:
                 raise ValueError(f"unable to parse '{segment}' into date components")
@@ -79,27 +93,27 @@ class timedelta(datetime.timedelta):
 
             # HH:MM:SS[.ssssss]
             case _, _, ":", _, _, ":", _, _, ".", *_:
-                yield cls.Component(segment[0:2], "hours", 24)
-                yield cls.Component(segment[3:5], "minutes", 60)
-                yield cls.Component(segment[6:15], "seconds", 60)
+                yield cls.Component(segment[0:2], TimeUnit.hours, 24)
+                yield cls.Component(segment[3:5], TimeUnit.minutes, 60)
+                yield cls.Component(segment[6:15], TimeUnit.seconds, 60)
 
             # HH:MM:SS
             case _, _, ":", _, _, ":", _, _:
-                yield cls.Component(segment[0:2], "hours", 24)
-                yield cls.Component(segment[3:5], "minutes", 60)
-                yield cls.Component(segment[6:8], "seconds", 60)
+                yield cls.Component(segment[0:2], TimeUnit.hours, 24)
+                yield cls.Component(segment[3:5], TimeUnit.minutes, 60)
+                yield cls.Component(segment[6:8], TimeUnit.seconds, 60)
 
             # HHMMSS[.ssssss]
             case _, _, _, _, _, _, ".", *_:
-                yield cls.Component(segment[0:2], "hours", 24)
-                yield cls.Component(segment[2:4], "minutes", 60)
-                yield cls.Component(segment[4:13], "seconds", 60)
+                yield cls.Component(segment[0:2], TimeUnit.hours, 24)
+                yield cls.Component(segment[2:4], TimeUnit.minutes, 60)
+                yield cls.Component(segment[4:13], TimeUnit.seconds, 60)
 
             # HHMMSS
             case _, _, _, _, _, _:
-                yield cls.Component(segment[0:2], "hours", 24)
-                yield cls.Component(segment[2:4], "minutes", 60)
-                yield cls.Component(segment[4:6], "seconds", 60)
+                yield cls.Component(segment[0:2], TimeUnit.hours, 24)
+                yield cls.Component(segment[2:4], TimeUnit.minutes, 60)
+                yield cls.Component(segment[4:6], TimeUnit.seconds, 60)
 
             case _:
                 raise ValueError(f"unable to parse '{segment}' into time components")
@@ -112,9 +126,9 @@ class timedelta(datetime.timedelta):
         in order of largest-to-smallest unit from left-to-right (with the exception of
         week measurements, which must be the only measurement in the string if present).
         """
-        date_context = iter((("Y", "years"), ("M", "months"), ("D", "days")))
-        time_context = iter((("H", "hours"), ("M", "minutes"), ("S", "seconds")))
-        week_context = iter((("W", "weeks"),))
+        date_context = iter(DateUnit)
+        time_context = iter(TimeUnit)
+        week_context = iter(WeekUnit)
 
         context, value, unit = date_context, "", None
         for char in duration:
@@ -132,9 +146,9 @@ class timedelta(datetime.timedelta):
                 pass
 
             assert not (context is week_context and unit), "cannot mix weeks with other units"
-            for delimiter, unit in context:
-                if char == delimiter:
-                    yield cls.Component(value, unit)
+            for unit in context:
+                if char == unit:
+                    yield timedelta.Component(value, unit)
                     value = ""
                     break
             else:
@@ -172,7 +186,7 @@ class timedelta(datetime.timedelta):
         :raises: `ValueError` with an explanatory message when parsing fails
         """
         try:
-            return cls(**{m.unit: m.quantity for m in cls._parse_duration(duration) if m.valid})
+            return cls(**{m.unit.name: m.quantity for m in cls._parse_duration(duration) if m.valid})
         except (AssertionError, ValueError) as exc:
             raise ValueError(f"could not parse duration '{duration}': {exc}") from exc
 

--- a/src/timedelta_isoformat/__init__.py
+++ b/src/timedelta_isoformat/__init__.py
@@ -1,21 +1,8 @@
 """Supplemental ISO8601 duration format support for :py:class:`datetime.timedelta`"""
-from dataclasses import dataclass
 import datetime
 from typing import Iterable, Tuple, TypeAlias
 
 _DECIMAL_POINTS = frozenset(",.")
-
-
-@dataclass
-class DateComponent:
-    value: str
-    unit: str
-    limit: int | None = None
-
-
-@dataclass
-class TimeComponent(DateComponent):
-    limit: int
 
 
 class timedelta(datetime.timedelta):
@@ -23,7 +10,7 @@ class timedelta(datetime.timedelta):
     ISO8601-style parsing and formatting.
     """
 
-    Components: TypeAlias = Iterable[DateComponent | TimeComponent]
+    Components: TypeAlias = Iterable[Tuple[str, str, int | None]]
     Measurements: TypeAlias = Iterable[Tuple[str, float]]
 
     def __repr__(self) -> str:
@@ -35,25 +22,25 @@ class timedelta(datetime.timedelta):
 
             # YYYY-DDD
             case _, _, _, _, "-", _, _, _:
-                yield DateComponent(segment[0:4], "years")
-                yield DateComponent(segment[5:8], "days", 366)
+                yield segment[0:4], "years", None
+                yield segment[5:8], "days", 366
 
             # YYYY-MM-DD
             case _, _, _, _, "-", _, _, "-", _, _:
-                yield DateComponent(segment[0:4], "years")
-                yield DateComponent(segment[5:7], "months", 12)
-                yield DateComponent(segment[8:10], "days", 31)
+                yield segment[0:4], "years", None
+                yield segment[5:7], "months", 12
+                yield segment[8:10], "days", 31
 
             # YYYYDDD
             case _, _, _, _, _, _, _:
-                yield DateComponent(segment[0:4], "years")
-                yield DateComponent(segment[4:7], "days", 366)
+                yield segment[0:4], "years", None
+                yield segment[4:7], "days", 366
 
             # YYYYMMDD
             case _, _, _, _, _, _, _, _:
-                yield DateComponent(segment[0:4], "years")
-                yield DateComponent(segment[4:6], "months", 12)
-                yield DateComponent(segment[6:8], "days", 31)
+                yield segment[0:4], "years", None
+                yield segment[4:6], "months", 12
+                yield segment[6:8], "days", 31
 
             case _:
                 raise ValueError(f"unable to parse '{segment}' into date components")
@@ -64,27 +51,27 @@ class timedelta(datetime.timedelta):
 
             # HH:MM:SS[.ssssss]
             case _, _, ":", _, _, ":", _, _, ".", *_:
-                yield TimeComponent(segment[0:2], "hours", 24)
-                yield TimeComponent(segment[3:5], "minutes", 60)
-                yield TimeComponent(segment[6:15], "seconds", 60)
+                yield segment[0:2], "hours", 24
+                yield segment[3:5], "minutes", 60
+                yield segment[6:15], "seconds", 60
 
             # HH:MM:SS
             case _, _, ":", _, _, ":", _, _:
-                yield TimeComponent(segment[0:2], "hours", 24)
-                yield TimeComponent(segment[3:5], "minutes", 60)
-                yield TimeComponent(segment[6:8], "seconds", 60)
+                yield segment[0:2], "hours", 24
+                yield segment[3:5], "minutes", 60
+                yield segment[6:8], "seconds", 60
 
             # HHMMSS[.ssssss]
             case _, _, _, _, _, _, ".", *_:
-                yield TimeComponent(segment[0:2], "hours", 24)
-                yield TimeComponent(segment[2:4], "minutes", 60)
-                yield TimeComponent(segment[4:13], "seconds", 60)
+                yield segment[0:2], "hours", 24
+                yield segment[2:4], "minutes", 60
+                yield segment[4:13], "seconds", 60
 
             # HHMMSS
             case _, _, _, _, _, _:
-                yield TimeComponent(segment[0:2], "hours", 24)
-                yield TimeComponent(segment[2:4], "minutes", 60)
-                yield TimeComponent(segment[4:6], "seconds", 60)
+                yield segment[0:2], "hours", 24
+                yield segment[2:4], "minutes", 60
+                yield segment[4:6], "seconds", 60
 
             case _:
                 raise ValueError(f"unable to parse '{segment}' into time components")
@@ -124,7 +111,7 @@ class timedelta(datetime.timedelta):
             assert not (unit and context is week_context), "cannot mix weeks with other units"
             for delimiter, unit in context:
                 if char == delimiter:
-                    yield DateComponent(head + tail, unit)
+                    yield head + tail, unit, None
                     head = tail = ""
                     break
             else:
@@ -147,22 +134,20 @@ class timedelta(datetime.timedelta):
 
         if duration[-1].isupper():
             components = cls._from_designators(duration[1:])
-            yield from cls._to_measurements(components)
+            yield from cls._to_measurements(components, inclusive_limit=True)
             return
 
         date_segment, _, time_segment = duration[1:].partition("T")
         if date_segment:
             components = cls._from_date(date_segment)
-            yield from cls._to_measurements(components)
+            yield from cls._to_measurements(components, inclusive_limit=True)
         if time_segment:
             components = cls._from_time(time_segment)
-            yield from cls._to_measurements(components)
+            yield from cls._to_measurements(components, inclusive_limit=False)
 
     @staticmethod
-    def _to_measurements(components: Components) -> Measurements:
-        for component in components:
-            value, unit, limit = component.value, component.unit, component.limit
-            inclusive_limit = not isinstance(component, TimeComponent)
+    def _to_measurements(components: Components, inclusive_limit: bool) -> Measurements:
+        for value, unit, limit in components:
             try:
                 assert value[0].isdigit()
                 quantity = float(value)

--- a/src/timedelta_isoformat/__init__.py
+++ b/src/timedelta_isoformat/__init__.py
@@ -1,9 +1,23 @@
 """Supplemental ISO8601 duration format support for :py:class:`datetime.timedelta`"""
 from dataclasses import dataclass
 import datetime
+from enum import StrEnum
 from typing import Iterable, Tuple, TypeAlias
 
 _NUMBER_FORMAT = frozenset("0123456789,.")
+
+class DateUnit(StrEnum):
+    years = "Y"
+    months = "M"
+    days = "D"
+
+class TimeUnit(StrEnum):
+    hours = "H"
+    minutes = "M"
+    seconds = "S"
+
+class WeekUnit(StrEnum):
+    weeks = "W"
 
 
 class timedelta(datetime.timedelta):
@@ -18,7 +32,7 @@ class timedelta(datetime.timedelta):
         limit: int | None = None
 
         def __iter__(self):
-            return iter((self.value, self.unit, self.limit))
+            return iter((self.value, self.unit.name, self.limit))
 
     Components: TypeAlias = Iterable[Component]
     Measurements: TypeAlias = Iterable[Tuple[str, float]]
@@ -32,25 +46,25 @@ class timedelta(datetime.timedelta):
 
             # YYYY-DDD
             case _, _, _, _, "-", _, _, _:
-                yield cls.Component(segment[0:4], "years")
-                yield cls.Component(segment[5:8], "days", 366)
+                yield cls.Component(segment[0:4], DateUnit.years)
+                yield cls.Component(segment[5:8], DateUnit.days, 366)
 
             # YYYY-MM-DD
             case _, _, _, _, "-", _, _, "-", _, _:
-                yield cls.Component(segment[0:4], "years")
-                yield cls.Component(segment[5:7], "months", 12)
-                yield cls.Component(segment[8:10], "days", 31)
+                yield cls.Component(segment[0:4], DateUnit.years)
+                yield cls.Component(segment[5:7], DateUnit.months, 12)
+                yield cls.Component(segment[8:10], DateUnit.days, 31)
 
             # YYYYDDD
             case _, _, _, _, _, _, _:
-                yield cls.Component(segment[0:4], "years")
-                yield cls.Component(segment[4:7], "days", 366)
+                yield cls.Component(segment[0:4], DateUnit.years)
+                yield cls.Component(segment[4:7], DateUnit.days, 366)
 
             # YYYYMMDD
             case _, _, _, _, _, _, _, _:
-                yield cls.Component(segment[0:4], "years")
-                yield cls.Component(segment[4:6], "months", 12)
-                yield cls.Component(segment[6:8], "days", 31)
+                yield cls.Component(segment[0:4], DateUnit.years)
+                yield cls.Component(segment[4:6], DateUnit.months, 12)
+                yield cls.Component(segment[6:8], DateUnit.days, 31)
 
             case _:
                 raise ValueError(f"unable to parse '{segment}' into date components")
@@ -61,27 +75,27 @@ class timedelta(datetime.timedelta):
 
             # HH:MM:SS[.ssssss]
             case _, _, ":", _, _, ":", _, _, ".", *_:
-                yield cls.Component(segment[0:2], "hours", 24)
-                yield cls.Component(segment[3:5], "minutes", 60)
-                yield cls.Component(segment[6:15], "seconds", 60)
+                yield cls.Component(segment[0:2], TimeUnit.hours, 24)
+                yield cls.Component(segment[3:5], TimeUnit.minutes, 60)
+                yield cls.Component(segment[6:15], TimeUnit.seconds, 60)
 
             # HH:MM:SS
             case _, _, ":", _, _, ":", _, _:
-                yield cls.Component(segment[0:2], "hours", 24)
-                yield cls.Component(segment[3:5], "minutes", 60)
-                yield cls.Component(segment[6:8], "seconds", 60)
+                yield cls.Component(segment[0:2], TimeUnit.hours, 24)
+                yield cls.Component(segment[3:5], TimeUnit.minutes, 60)
+                yield cls.Component(segment[6:8], TimeUnit.seconds, 60)
 
             # HHMMSS[.ssssss]
             case _, _, _, _, _, _, ".", *_:
-                yield cls.Component(segment[0:2], "hours", 24)
-                yield cls.Component(segment[2:4], "minutes", 60)
-                yield cls.Component(segment[4:13], "seconds", 60)
+                yield cls.Component(segment[0:2], TimeUnit.hours, 24)
+                yield cls.Component(segment[2:4], TimeUnit.minutes, 60)
+                yield cls.Component(segment[4:13], TimeUnit.seconds, 60)
 
             # HHMMSS
             case _, _, _, _, _, _:
-                yield cls.Component(segment[0:2], "hours", 24)
-                yield cls.Component(segment[2:4], "minutes", 60)
-                yield cls.Component(segment[4:6], "seconds", 60)
+                yield cls.Component(segment[0:2], TimeUnit.hours, 24)
+                yield cls.Component(segment[2:4], TimeUnit.minutes, 60)
+                yield cls.Component(segment[4:6], TimeUnit.seconds, 60)
 
             case _:
                 raise ValueError(f"unable to parse '{segment}' into time components")
@@ -94,9 +108,9 @@ class timedelta(datetime.timedelta):
         in order of largest-to-smallest unit from left-to-right (with the exception of
         week measurements, which must be the only measurement in the string if present).
         """
-        date_context = iter((("Y", "years"), ("M", "months"), ("D", "days")))
-        time_context = iter((("H", "hours"), ("M", "minutes"), ("S", "seconds")))
-        week_context = iter((("W", "weeks"),))
+        date_context = iter(DateUnit)
+        time_context = iter(TimeUnit)
+        week_context = iter(WeekUnit)
 
         context, value, unit = date_context, "", None
         for char in duration:
@@ -114,9 +128,9 @@ class timedelta(datetime.timedelta):
                 pass
 
             assert not (context is week_context and unit), "cannot mix weeks with other units"
-            for delimiter, unit in context:
-                if char == delimiter:
-                    yield cls.Component(value, unit)
+            for unit in context:
+                if char == unit:
+                    yield timedelta.Component(value, unit)
                     value = ""
                     break
             else:

--- a/src/timedelta_isoformat/__init__.py
+++ b/src/timedelta_isoformat/__init__.py
@@ -14,19 +14,18 @@ class DateComponent:
     quantity: float = 0
 
     def __post_init__(self):
-        try:
-            assert self.value[0].isdigit()
-            self.quantity = float(self.value)
-        except (AssertionError, IndexError, ValueError) as exc:
-            msg = f"unable to parse '{self.value}' as a positive decimal"
-            raise ValueError(msg) from exc
-        if not self.limit:
-            return
+        value, unit, limit = self.value, self.unit, self.limit
         inclusive_limit = not isinstance(self, TimeComponent)
-        if 0 <= self.quantity <= self.limit if inclusive_limit else 0 <= self.quantity < self.limit:
-            return
-        bounds = f"[0..{self.limit}" + ("]" if inclusive_limit else ")")
-        raise ValueError(f"{self.unit} value of {self.value} exceeds range {bounds}")
+        try:
+            assert value[0].isdigit()
+            quantity = float(value)
+        except (AssertionError, IndexError, ValueError) as exc:
+            msg = f"unable to parse '{value}' as a positive decimal"
+            raise ValueError(msg) from exc
+        if limit and not (0 <= quantity <= limit if inclusive_limit else 0 <= quantity < limit):
+            bounds = f"[0..{limit}" + ("]" if inclusive_limit else ")")
+            raise ValueError(f"{unit} value of {value} exceeds range {bounds}")
+        self.quantity = quantity
 
     def astuple(self):
         if self.quantity:

--- a/src/timedelta_isoformat/__init__.py
+++ b/src/timedelta_isoformat/__init__.py
@@ -13,7 +13,7 @@ class DateComponent:
     limit: int | None = None
     quantity: float = 0
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         try:
             assert self.value[0].isdigit()
             self.quantity = float(self.value)
@@ -28,11 +28,8 @@ class DateComponent:
         bounds = f"[0..{self.limit}" + ("]" if inclusive_limit else ")")
         raise ValueError(f"{self.unit} value of {self.value} exceeds range {bounds}")
 
-    def astuple(self):
-        if self.quantity:
-            return self.unit, self.quantity
-        else:
-            return "weeks", 0
+    def astuple(self) -> Tuple[str, float]:
+        return self.unit, self.quantity
 
 
 @dataclass
@@ -46,7 +43,6 @@ class timedelta(datetime.timedelta):
     """
 
     Components: TypeAlias = Iterable[DateComponent | TimeComponent]
-    Measurements: TypeAlias = Iterable[Tuple[str, float]]
 
     def __repr__(self) -> str:
         return f"timedelta_isoformat.{super().__repr__()}"
@@ -57,25 +53,25 @@ class timedelta(datetime.timedelta):
 
             # YYYY-DDD
             case _, _, _, _, "-", _, _, _:
-                yield DateComponent(segment[0:4], "years").astuple()
-                yield DateComponent(segment[5:8], "days", 366).astuple()
+                yield DateComponent(segment[0:4], "years")
+                yield DateComponent(segment[5:8], "days", 366)
 
             # YYYY-MM-DD
             case _, _, _, _, "-", _, _, "-", _, _:
-                yield DateComponent(segment[0:4], "years").astuple()
-                yield DateComponent(segment[5:7], "months", 12).astuple()
-                yield DateComponent(segment[8:10], "days", 31).astuple()
+                yield DateComponent(segment[0:4], "years")
+                yield DateComponent(segment[5:7], "months", 12)
+                yield DateComponent(segment[8:10], "days", 31)
 
             # YYYYDDD
             case _, _, _, _, _, _, _:
-                yield DateComponent(segment[0:4], "years").astuple()
-                yield DateComponent(segment[4:7], "days", 366).astuple()
+                yield DateComponent(segment[0:4], "years")
+                yield DateComponent(segment[4:7], "days", 366)
 
             # YYYYMMDD
             case _, _, _, _, _, _, _, _:
-                yield DateComponent(segment[0:4], "years").astuple()
-                yield DateComponent(segment[4:6], "months", 12).astuple()
-                yield DateComponent(segment[6:8], "days", 31).astuple()
+                yield DateComponent(segment[0:4], "years")
+                yield DateComponent(segment[4:6], "months", 12)
+                yield DateComponent(segment[6:8], "days", 31)
 
             case _:
                 raise ValueError(f"unable to parse '{segment}' into date components")
@@ -86,27 +82,27 @@ class timedelta(datetime.timedelta):
 
             # HH:MM:SS[.ssssss]
             case _, _, ":", _, _, ":", _, _, ".", *_:
-                yield TimeComponent(segment[0:2], "hours", 24).astuple()
-                yield TimeComponent(segment[3:5], "minutes", 60).astuple()
-                yield TimeComponent(segment[6:15], "seconds", 60).astuple()
+                yield TimeComponent(segment[0:2], "hours", 24)
+                yield TimeComponent(segment[3:5], "minutes", 60)
+                yield TimeComponent(segment[6:15], "seconds", 60)
 
             # HH:MM:SS
             case _, _, ":", _, _, ":", _, _:
-                yield TimeComponent(segment[0:2], "hours", 24).astuple()
-                yield TimeComponent(segment[3:5], "minutes", 60).astuple()
-                yield TimeComponent(segment[6:8], "seconds", 60).astuple()
+                yield TimeComponent(segment[0:2], "hours", 24)
+                yield TimeComponent(segment[3:5], "minutes", 60)
+                yield TimeComponent(segment[6:8], "seconds", 60)
 
             # HHMMSS[.ssssss]
             case _, _, _, _, _, _, ".", *_:
-                yield TimeComponent(segment[0:2], "hours", 24).astuple()
-                yield TimeComponent(segment[2:4], "minutes", 60).astuple()
-                yield TimeComponent(segment[4:13], "seconds", 60).astuple()
+                yield TimeComponent(segment[0:2], "hours", 24)
+                yield TimeComponent(segment[2:4], "minutes", 60)
+                yield TimeComponent(segment[4:13], "seconds", 60)
 
             # HHMMSS
             case _, _, _, _, _, _:
-                yield TimeComponent(segment[0:2], "hours", 24).astuple()
-                yield TimeComponent(segment[2:4], "minutes", 60).astuple()
-                yield TimeComponent(segment[4:6], "seconds", 60).astuple()
+                yield TimeComponent(segment[0:2], "hours", 24)
+                yield TimeComponent(segment[2:4], "minutes", 60)
+                yield TimeComponent(segment[4:6], "seconds", 60)
 
             case _:
                 raise ValueError(f"unable to parse '{segment}' into time components")
@@ -146,7 +142,7 @@ class timedelta(datetime.timedelta):
             assert not (unit and context is week_context), "cannot mix weeks with other units"
             for delimiter, unit in context:
                 if char == delimiter:
-                    yield DateComponent(head + tail, unit).astuple()
+                    yield DateComponent(head + tail, unit)
                     head = tail = ""
                     break
             else:
@@ -155,7 +151,7 @@ class timedelta(datetime.timedelta):
         assert unit, "no measurements found"
 
     @classmethod
-    def _from_duration(cls, duration: str) -> Measurements:
+    def _from_duration(cls, duration: str) -> Components:
         """Selects and runs an appropriate parser for ISO-8601 duration strings
 
         The format of these strings is composed of two segments; date measurements
@@ -184,7 +180,7 @@ class timedelta(datetime.timedelta):
         :raises: `ValueError` with an explanatory message when parsing fails
         """
         try:
-            return cls(**dict(cls._from_duration(duration)))
+            return cls(**dict(c.astuple() for c in cls._from_duration(duration) if c.quantity))
         except (AssertionError, ValueError) as exc:
             raise ValueError(f"could not parse duration '{duration}': {exc}") from exc
 

--- a/src/timedelta_isoformat/__init__.py
+++ b/src/timedelta_isoformat/__init__.py
@@ -14,18 +14,19 @@ class DateComponent:
     quantity: float = 0
 
     def __post_init__(self):
-        value, unit, limit = self.value, self.unit, self.limit
-        inclusive_limit = not isinstance(self, TimeComponent)
         try:
-            assert value[0].isdigit()
-            quantity = float(value)
+            assert self.value[0].isdigit()
+            self.quantity = float(self.value)
         except (AssertionError, IndexError, ValueError) as exc:
-            msg = f"unable to parse '{value}' as a positive decimal"
+            msg = f"unable to parse '{self.value}' as a positive decimal"
             raise ValueError(msg) from exc
-        if limit and not (0 <= quantity <= limit if inclusive_limit else 0 <= quantity < limit):
-            bounds = f"[0..{limit}" + ("]" if inclusive_limit else ")")
-            raise ValueError(f"{unit} value of {value} exceeds range {bounds}")
-        self.quantity = quantity
+        if not self.limit:
+            return
+        inclusive_limit = not isinstance(self, TimeComponent)
+        if 0 <= self.quantity <= self.limit if inclusive_limit else 0 <= self.quantity < self.limit:
+            return
+        bounds = f"[0..{self.limit}" + ("]" if inclusive_limit else ")")
+        raise ValueError(f"{self.unit} value of {self.value} exceeds range {bounds}")
 
     def astuple(self):
         if self.quantity:

--- a/src/timedelta_isoformat/__init__.py
+++ b/src/timedelta_isoformat/__init__.py
@@ -156,13 +156,14 @@ class timedelta(datetime.timedelta):
                 pass
 
             assert not (unit and context is week_context), "cannot mix weeks with other units"
-
-            # Note: this advances and may exhaust the context iterator
-            if char not in context:
+            for delimiter in context:
+                if char == delimiter:
+                    unit = char
+                    yield (TimeComponent if context is time_context else DateComponent)(head + tail, unit)
+                    head = tail = ""
+                    break
+            else:
                 raise ValueError(f"unexpected character '{char}'")
-
-            yield (TimeComponent if context is time_context else DateComponent)(head + tail, char)
-            head, tail, unit = "", "", char
 
         assert unit, "no measurements found"
 

--- a/src/timedelta_isoformat/__init__.py
+++ b/src/timedelta_isoformat/__init__.py
@@ -1,23 +1,9 @@
 """Supplemental ISO8601 duration format support for :py:class:`datetime.timedelta`"""
 from dataclasses import dataclass
 import datetime
-from enum import StrEnum
 from typing import Iterable, Tuple, TypeAlias
 
 _DECIMAL_POINTS = frozenset(",.")
-
-
-class DateUnit(StrEnum):
-    years = "Y"
-    months = "M"
-    weeks = "W"
-    days = "D"
-
-
-class TimeUnit(StrEnum):
-    hours = "H"
-    minutes = "M"
-    seconds = "S"
 
 
 @dataclass
@@ -26,7 +12,6 @@ class DateComponent:
     unit: str
     limit: int | None = None
     quantity: float = 0
-    unit_type: TypeAlias = DateUnit
 
     def __post_init__(self) -> None:
         try:
@@ -41,16 +26,15 @@ class DateComponent:
         if 0 <= self.quantity <= self.limit if inclusive_limit else 0 <= self.quantity < self.limit:
             return
         bounds = f"[0..{self.limit}" + ("]" if inclusive_limit else ")")
-        raise ValueError(f"{self.unit_type(self.unit).name} value of {self.value} exceeds range {bounds}")
+        raise ValueError(f"{self.unit} value of {self.value} exceeds range {bounds}")
 
     def astuple(self) -> Tuple[str, float]:
-        return self.unit_type(self.unit).name, self.quantity
+        return self.unit, self.quantity
 
 
 @dataclass
 class TimeComponent(DateComponent):
     limit: int
-    unit_type: TypeAlias = TimeUnit
 
 
 class timedelta(datetime.timedelta):
@@ -69,25 +53,25 @@ class timedelta(datetime.timedelta):
 
             # YYYY-DDD
             case _, _, _, _, "-", _, _, _:
-                yield DateComponent(segment[0:4], "Y")
-                yield DateComponent(segment[5:8], "D", 366)
+                yield DateComponent(segment[0:4], "years")
+                yield DateComponent(segment[5:8], "days", 366)
 
             # YYYY-MM-DD
             case _, _, _, _, "-", _, _, "-", _, _:
-                yield DateComponent(segment[0:4], "Y")
-                yield DateComponent(segment[5:7], "M", 12)
-                yield DateComponent(segment[8:10], "D", 31)
+                yield DateComponent(segment[0:4], "years")
+                yield DateComponent(segment[5:7], "months", 12)
+                yield DateComponent(segment[8:10], "days", 31)
 
             # YYYYDDD
             case _, _, _, _, _, _, _:
-                yield DateComponent(segment[0:4], "Y")
-                yield DateComponent(segment[4:7], "D", 366)
+                yield DateComponent(segment[0:4], "years")
+                yield DateComponent(segment[4:7], "days", 366)
 
             # YYYYMMDD
             case _, _, _, _, _, _, _, _:
-                yield DateComponent(segment[0:4], "Y")
-                yield DateComponent(segment[4:6], "M", 12)
-                yield DateComponent(segment[6:8], "D", 31)
+                yield DateComponent(segment[0:4], "years")
+                yield DateComponent(segment[4:6], "months", 12)
+                yield DateComponent(segment[6:8], "days", 31)
 
             case _:
                 raise ValueError(f"unable to parse '{segment}' into date components")
@@ -98,27 +82,27 @@ class timedelta(datetime.timedelta):
 
             # HH:MM:SS[.ssssss]
             case _, _, ":", _, _, ":", _, _, ".", *_:
-                yield TimeComponent(segment[0:2], "H", 24)
-                yield TimeComponent(segment[3:5], "M", 60)
-                yield TimeComponent(segment[6:15], "S", 60)
+                yield TimeComponent(segment[0:2], "hours", 24)
+                yield TimeComponent(segment[3:5], "minutes", 60)
+                yield TimeComponent(segment[6:15], "seconds", 60)
 
             # HH:MM:SS
             case _, _, ":", _, _, ":", _, _:
-                yield TimeComponent(segment[0:2], "H", 24)
-                yield TimeComponent(segment[3:5], "M", 60)
-                yield TimeComponent(segment[6:8], "S", 60)
+                yield TimeComponent(segment[0:2], "hours", 24)
+                yield TimeComponent(segment[3:5], "minutes", 60)
+                yield TimeComponent(segment[6:8], "seconds", 60)
 
             # HHMMSS[.ssssss]
             case _, _, _, _, _, _, ".", *_:
-                yield TimeComponent(segment[0:2], "H", 24)
-                yield TimeComponent(segment[2:4], "M", 60)
-                yield TimeComponent(segment[4:13], "S", 60)
+                yield TimeComponent(segment[0:2], "hours", 24)
+                yield TimeComponent(segment[2:4], "minutes", 60)
+                yield TimeComponent(segment[4:13], "seconds", 60)
 
             # HHMMSS
             case _, _, _, _, _, _:
-                yield TimeComponent(segment[0:2], "H", 24)
-                yield TimeComponent(segment[2:4], "M", 60)
-                yield TimeComponent(segment[4:6], "S", 60)
+                yield TimeComponent(segment[0:2], "hours", 24)
+                yield TimeComponent(segment[2:4], "minutes", 60)
+                yield TimeComponent(segment[4:6], "seconds", 60)
 
             case _:
                 raise ValueError(f"unable to parse '{segment}' into time components")
@@ -131,9 +115,9 @@ class timedelta(datetime.timedelta):
         in order of largest-to-smallest unit from left-to-right (with the exception of
         week measurements, which must be the only measurement in the string if present).
         """
-        date_context = iter(("Y", "M", "D"))
-        time_context = iter(("H", "M", "S"))
-        week_context = iter(("W",))
+        date_context = iter((("Y", "years"), ("M", "months"), ("D", "days")))
+        time_context = iter((("H", "hours"), ("M", "minutes"), ("S", "seconds")))
+        week_context = iter((("W", "weeks"),))
 
         context, head, tail, unit = date_context, "", "", None
         for char in duration:
@@ -156,10 +140,9 @@ class timedelta(datetime.timedelta):
                 pass
 
             assert not (unit and context is week_context), "cannot mix weeks with other units"
-            for delimiter in context:
+            for delimiter, unit in context:
                 if char == delimiter:
-                    unit = char
-                    yield (TimeComponent if context is time_context else DateComponent)(head + tail, unit)
+                    yield DateComponent(head + tail, unit)
                     head = tail = ""
                     break
             else:

--- a/src/timedelta_isoformat/__init__.py
+++ b/src/timedelta_isoformat/__init__.py
@@ -22,8 +22,6 @@ class DateComponent:
         except (AssertionError, IndexError, ValueError) as exc:
             msg = f"unable to parse '{value}' as a positive decimal"
             raise ValueError(msg) from exc
-        if not quantity:
-            return
         if limit and not (0 <= quantity <= limit if inclusive_limit else 0 <= quantity < limit):
             bounds = f"[0..{limit}" + ("]" if inclusive_limit else ")")
             raise ValueError(f"{unit} value of {value} exceeds range {bounds}")

--- a/tests/test_timedelta_isoformat.py
+++ b/tests/test_timedelta_isoformat.py
@@ -70,8 +70,8 @@ invalid_durations = [
     ("P1WT1H", "cannot mix weeks with other units"),
     ("P0Y1W", "cannot mix weeks with other units"),
     # incorrect quantities
-    ("PT0.0.0S", "unable to parse '0.0.0' as a positive decimal"),
-    ("P1.,0D", "unable to parse '1..0' as a positive decimal"),
+    ("PT0.0.0S", "could not convert string to float: '0.0.0'"),
+    ("P1.,0D", "could not convert string to float: '1..0'"),
     # date-format durations exceeding calendar limits
     ("P0000-367", "days value of 367 exceeds range [0..366]"),
     ("P0000-400", "days value of 400 exceeds range [0..366]"),
@@ -81,7 +81,7 @@ invalid_durations = [
     ("PT15:25:60", "seconds value of 60 exceeds range [0..60)"),
     ("PT24:00:00", "hours value of 24 exceeds range [0..24)"),
     # invalid date-format style durations
-    ("P0000-1-0", "unable to parse '1-0' as a positive decimal"),
+    ("P0000-1-0", "could not convert string to float: '1-0'"),
     ("PT1:2:3", "unable to parse '1:2:3' into time components"),
     ("PT01:0203", "unable to parse '01:0203' into time components"),
     ("PT01", "unable to parse '01' into time components"),

--- a/tests/test_timedelta_isoformat.py
+++ b/tests/test_timedelta_isoformat.py
@@ -88,8 +88,8 @@ invalid_durations = [
     ("PT01:02:3.4", "unable to parse '01:02:3.4' into time components"),
     ("P0000y00m00", "unable to parse '0000y00m00' into date components"),
     # decimals must have a non-empty integer value before the separator
-    ("PT.5S", "unable to parse '.5' as a positive decimal"),
-    ("P1M.1D", "unable to parse '.1' as a positive decimal"),
+    ("PT.5S", "unexpected character '.'"),
+    ("P1M.1D", "unexpected character '.'"),
     # segment repetition
     ("PT5MT5S", "unexpected character 'T'"),
     ("P1W2W", "cannot mix weeks with other units"),

--- a/tests/test_timedelta_isoformat.py
+++ b/tests/test_timedelta_isoformat.py
@@ -95,7 +95,7 @@ invalid_durations = [
     ("P1W2W", "cannot mix weeks with other units"),
     # segments out-of-order
     ("P1DT5S2W", "cannot mix weeks with other units"),
-    ("P1W1D", "unexpected character 'D'"),
+    ("P1W1D", "cannot mix weeks with other units"),
     # unexpected characters within date/time components
     ("PT01:-2:03", "unable to parse '-2' as a positive decimal"),
     ("P000000.1", "unable to parse '.1' as a positive decimal"),

--- a/tests/test_timedelta_isoformat.py
+++ b/tests/test_timedelta_isoformat.py
@@ -65,9 +65,9 @@ invalid_durations = [
     ("P0DT5M1H", "unexpected character 'H'"),
     # invalid units within segment
     ("PT1DS", "unexpected character 'D'"),
-    ("P1HT0S", "unexpected character 'H'"),
+    ("P1HT0S", "unexpected character 'T'"),
     # mixing week units with other units
-    ("P1WT1H", "cannot mix weeks with other units"),
+    ("P1WT1H", "unexpected character 'T'"),
     ("P0Y1W", "cannot mix weeks with other units"),
     # incorrect quantities
     ("PT0.0.0S", "unable to parse '0.0.0' as a positive decimal"),
@@ -94,7 +94,7 @@ invalid_durations = [
     ("PT5MT5S", "unexpected character 'T'"),
     ("P1W2W", "unexpected character 'W'"),
     # segments out-of-order
-    ("P1DT5S2W", "unexpected character 'W'"),
+    ("P1DT5S2W", "cannot mix weeks with other units"),
     ("P1W1D", "unexpected character 'D'"),
     # unexpected characters within date/time components
     ("PT01:-2:03", "unable to parse '-2' as a positive decimal"),

--- a/tests/test_timedelta_isoformat.py
+++ b/tests/test_timedelta_isoformat.py
@@ -112,8 +112,6 @@ invalid_durations = [
     # scientific notation in designated values
     ("P1.0e+1D", "unexpected character 'e'"),
     ("P10.0E-1D", "unexpected character 'E'"),
-    # attempt to cause the parser to confuse duration tokens and timedelta arguments
-    ("P1years1M", "unexpected character 'y'"),
 ]
 
 # ambiguous cases

--- a/tests/test_timedelta_isoformat.py
+++ b/tests/test_timedelta_isoformat.py
@@ -95,7 +95,7 @@ invalid_durations = [
     ("P1W2W", "cannot mix weeks with other units"),
     # segments out-of-order
     ("P1DT5S2W", "cannot mix weeks with other units"),
-    ("P1W1D", "cannot mix weeks with other units"),
+    ("P1W1D", "unexpected character 'D'"),
     # unexpected characters within date/time components
     ("PT01:-2:03", "unable to parse '-2' as a positive decimal"),
     ("P000000.1", "unable to parse '.1' as a positive decimal"),

--- a/tests/test_timedelta_isoformat.py
+++ b/tests/test_timedelta_isoformat.py
@@ -70,8 +70,8 @@ invalid_durations = [
     ("P1WT1H", "cannot mix weeks with other units"),
     ("P0Y1W", "cannot mix weeks with other units"),
     # incorrect quantities
-    ("PT0.0.0S", "unable to parse '0.0.0' as a positive decimal"),
-    ("P1.,0D", "unable to parse '1.,0' as a positive decimal"),
+    ("PT0.0.0S", "unexpected character '.'"),
+    ("P1.,0D", "unexpected character ','"),
     # date-format durations exceeding calendar limits
     ("P0000-367", "days value of 367 exceeds range [0..366]"),
     ("P0000-400", "days value of 400 exceeds range [0..366]"),
@@ -117,8 +117,8 @@ invalid_durations = [
     ("P1years1M", "unexpected character 'y'"),
     # components with missing designators
     ("PT1H2", "unable to parse '1H2' into time components"),
-    ("P20D4T", "expected a unit designator after '4'"),
-    ("P1D5T", "expected a unit designator after '5'"),
+    ("P20D4T", "missing unit designator after '4'"),
+    ("P1D5T", "missing unit designator after '5'"),
 ]
 
 # ambiguous cases

--- a/tests/test_timedelta_isoformat.py
+++ b/tests/test_timedelta_isoformat.py
@@ -70,8 +70,8 @@ invalid_durations = [
     ("P1WT1H", "cannot mix weeks with other units"),
     ("P0Y1W", "cannot mix weeks with other units"),
     # incorrect quantities
-    ("PT0.0.0S", "unexpected character '.'"),
-    ("P1.,0D", "unexpected character ','"),
+    ("PT0.0.0S", "unable to parse '0.0.0' as a positive decimal"),
+    ("P1.,0D", "unable to parse '1.,0' as a positive decimal"),
     # date-format durations exceeding calendar limits
     ("P0000-367", "days value of 367 exceeds range [0..366]"),
     ("P0000-400", "days value of 400 exceeds range [0..366]"),

--- a/tests/test_timedelta_isoformat.py
+++ b/tests/test_timedelta_isoformat.py
@@ -101,6 +101,7 @@ invalid_durations = [
     ("P000000.1", "unable to parse '.1' as a positive decimal"),
     ("PT000000--", "unable to parse '000000--' into time components"),
     ("PT00:00:00,-", "unable to parse '00:00:00,-' into time components"),
+    ("P-999Y", "unexpected character '-'"),
     # negative designator-separated values
     ("P-1DT0S", "unexpected character '-'"),
     ("P0M-2D", "unexpected character '-'"),

--- a/tests/test_timedelta_isoformat.py
+++ b/tests/test_timedelta_isoformat.py
@@ -114,10 +114,6 @@ invalid_durations = [
     ("P10.0E-1D", "unexpected character 'E'"),
     # attempt to cause the parser to confuse duration tokens and timedelta arguments
     ("P1years1M", "unexpected character 'y'"),
-    # components with missing designators
-    ("PT1H2", "unable to parse '1H2' into time components"),
-    ("P20D4T", "expected a unit designator after '4'"),
-    ("P1D5T", "expected a unit designator after '5'"),
 ]
 
 # ambiguous cases

--- a/tests/test_timedelta_isoformat.py
+++ b/tests/test_timedelta_isoformat.py
@@ -94,7 +94,7 @@ invalid_durations = [
     ("PT5MT5S", "unexpected character 'T'"),
     ("P1W2W", "cannot mix weeks with other units"),
     # segments out-of-order
-    ("P1DT5S2W", "unexpected character 'W'"),
+    ("P1DT5S2W", "cannot mix weeks with other units"),
     ("P1W1D", "cannot mix weeks with other units"),
     # unexpected characters within date/time components
     ("PT01:-2:03", "unable to parse '-2' as a positive decimal"),

--- a/tests/test_timedelta_isoformat.py
+++ b/tests/test_timedelta_isoformat.py
@@ -65,9 +65,9 @@ invalid_durations = [
     ("P0DT5M1H", "unexpected character 'H'"),
     # invalid units within segment
     ("PT1DS", "unexpected character 'D'"),
-    ("P1HT0S", "unexpected character 'T'"),
+    ("P1HT0S", "unexpected character 'H'"),
     # mixing week units with other units
-    ("P1WT1H", "unexpected character 'T'"),
+    ("P1WT1H", "cannot mix weeks with other units"),
     ("P0Y1W", "cannot mix weeks with other units"),
     # incorrect quantities
     ("PT0.0.0S", "unable to parse '0.0.0' as a positive decimal"),
@@ -94,7 +94,7 @@ invalid_durations = [
     ("PT5MT5S", "unexpected character 'T'"),
     ("P1W2W", "unexpected character 'W'"),
     # segments out-of-order
-    ("P1DT5S2W", "cannot mix weeks with other units"),
+    ("P1DT5S2W", "unexpected character 'W'"),
     ("P1W1D", "unexpected character 'D'"),
     # unexpected characters within date/time components
     ("PT01:-2:03", "unable to parse '-2' as a positive decimal"),

--- a/tests/test_timedelta_isoformat.py
+++ b/tests/test_timedelta_isoformat.py
@@ -70,8 +70,8 @@ invalid_durations = [
     ("P1WT1H", "cannot mix weeks with other units"),
     ("P0Y1W", "cannot mix weeks with other units"),
     # incorrect quantities
-    ("PT0.0.0S", "unable to parse '0.0.0' as a positive decimal"),
-    ("P1.,0D", "unable to parse '1.,0' as a positive decimal"),
+    ("PT0.0.0S", "unexpected character '.'"),
+    ("P1.,0D", "unexpected character ','"),
     # date-format durations exceeding calendar limits
     ("P0000-367", "days value of 367 exceeds range [0..366]"),
     ("P0000-400", "days value of 400 exceeds range [0..366]"),

--- a/tests/test_timedelta_isoformat.py
+++ b/tests/test_timedelta_isoformat.py
@@ -70,8 +70,8 @@ invalid_durations = [
     ("P1WT1H", "cannot mix weeks with other units"),
     ("P0Y1W", "cannot mix weeks with other units"),
     # incorrect quantities
-    ("PT0.0.0S", "unexpected character '.'"),
-    ("P1.,0D", "unexpected character ','"),
+    ("PT0.0.0S", "unable to parse '0.0.0' as a positive decimal"),
+    ("P1.,0D", "unable to parse '1..0' as a positive decimal"),
     # date-format durations exceeding calendar limits
     ("P0000-367", "days value of 367 exceeds range [0..366]"),
     ("P0000-400", "days value of 400 exceeds range [0..366]"),
@@ -88,8 +88,8 @@ invalid_durations = [
     ("PT01:02:3.4", "unable to parse '01:02:3.4' into time components"),
     ("P0000y00m00", "unable to parse '0000y00m00' into date components"),
     # decimals must have a non-empty integer value before the separator
-    ("PT.5S", "unexpected character '.'"),
-    ("P1M.1D", "unexpected character '.'"),
+    ("PT.5S", "unable to parse '.5' as a positive decimal"),
+    ("P1M.1D", "unable to parse '.1' as a positive decimal"),
     # segment repetition
     ("PT5MT5S", "unexpected character 'T'"),
     ("P1W2W", "cannot mix weeks with other units"),

--- a/tests/test_timedelta_isoformat.py
+++ b/tests/test_timedelta_isoformat.py
@@ -92,10 +92,10 @@ invalid_durations = [
     ("P1M.1D", "unable to parse '.1' as a positive decimal"),
     # segment repetition
     ("PT5MT5S", "unexpected character 'T'"),
-    ("P1W2W", "cannot mix weeks with other units"),
+    ("P1W2W", "unexpected character 'W'"),
     # segments out-of-order
     ("P1DT5S2W", "unexpected character 'W'"),
-    ("P1W1D", "cannot mix weeks with other units"),
+    ("P1W1D", "unexpected character 'D'"),
     # unexpected characters within date/time components
     ("PT01:-2:03", "unable to parse '-2' as a positive decimal"),
     ("P000000.1", "unable to parse '.1' as a positive decimal"),

--- a/tests/test_timedelta_isoformat.py
+++ b/tests/test_timedelta_isoformat.py
@@ -112,6 +112,12 @@ invalid_durations = [
     # scientific notation in designated values
     ("P1.0e+1D", "unexpected character 'e'"),
     ("P10.0E-1D", "unexpected character 'E'"),
+    # attempt to cause the parser to confuse duration tokens and timedelta arguments
+    ("P1years1M", "unexpected character 'y'"),
+    # components with missing designators
+    ("PT1H2", "unable to parse '1H2' into time components"),
+    ("P20D4T", "expected a unit designator after '4'"),
+    ("P1D5T", "expected a unit designator after '5'"),
 ]
 
 # ambiguous cases

--- a/tests/test_timedelta_isoformat.py
+++ b/tests/test_timedelta_isoformat.py
@@ -92,10 +92,10 @@ invalid_durations = [
     ("P1M.1D", "unable to parse '.1' as a positive decimal"),
     # segment repetition
     ("PT5MT5S", "unexpected character 'T'"),
-    ("P1W2W", "unexpected character 'W'"),
+    ("P1W2W", "cannot mix weeks with other units"),
     # segments out-of-order
     ("P1DT5S2W", "unexpected character 'W'"),
-    ("P1W1D", "unexpected character 'D'"),
+    ("P1W1D", "cannot mix weeks with other units"),
     # unexpected characters within date/time components
     ("PT01:-2:03", "unable to parse '-2' as a positive decimal"),
     ("P000000.1", "unable to parse '.1' as a positive decimal"),

--- a/tests/test_timedelta_isoformat.py
+++ b/tests/test_timedelta_isoformat.py
@@ -90,6 +90,10 @@ invalid_durations = [
     # decimals must have a non-empty integer value before the separator
     ("PT.5S", "unable to parse '.5' as a positive decimal"),
     ("P1M.1D", "unable to parse '.1' as a positive decimal"),
+    ("PT.5:00:00", ""),
+    ("PT5.:00:00", ""),
+    ("PT12:34:56e10", ""),
+    ("P0000-0.0", ""),
     # segment repetition
     ("PT5MT5S", "unexpected character 'T'"),
     ("P1W2W", "cannot mix weeks with other units"),

--- a/tests/test_timedelta_isoformat.py
+++ b/tests/test_timedelta_isoformat.py
@@ -55,7 +55,7 @@ invalid_durations = [
     ("PTT", "unexpected character 'T'"),
     ("PTP", "unexpected character 'P'"),
     # incomplete measurements
-    ("P0YD", "unable to parse '' as a positive decimal"),
+    ("P0YD", "unable to parse '' as a positive number"),
     # repeated designators
     ("P1DT1H3H1M", "unexpected character 'H'"),
     ("P1D3D", "unexpected character 'D'"),
@@ -81,15 +81,15 @@ invalid_durations = [
     ("PT15:25:60", "seconds value of 60 exceeds range [0..60)"),
     ("PT24:00:00", "hours value of 24 exceeds range [0..24)"),
     # invalid date-format style durations
-    ("P0000-1-0", "could not convert string to float: '1-0'"),
+    ("P0000-1-0", "unable to parse '1-0' as a positive number"),
     ("PT1:2:3", "unable to parse '1:2:3' into time components"),
     ("PT01:0203", "unable to parse '01:0203' into time components"),
     ("PT01", "unable to parse '01' into time components"),
     ("PT01:02:3.4", "unable to parse '01:02:3.4' into time components"),
     ("P0000y00m00", "unable to parse '0000y00m00' into date components"),
     # decimals must have a non-empty integer value before the separator
-    ("PT.5S", "unable to parse '.5' as a positive decimal"),
-    ("P1M.1D", "unable to parse '.1' as a positive decimal"),
+    ("PT.5S", "unable to parse '.5' as a positive number"),
+    ("P1M.1D", "unable to parse '.1' as a positive number"),
     ("PT.5:00:00", ""),
     ("PT5.:00:00", ""),
     ("PT12:34:56e10", ""),
@@ -101,8 +101,8 @@ invalid_durations = [
     ("P1DT5S2W", "cannot mix weeks with other units"),
     ("P1W1D", "cannot mix weeks with other units"),
     # unexpected characters within date/time components
-    ("PT01:-2:03", "unable to parse '-2' as a positive decimal"),
-    ("P000000.1", "unable to parse '.1' as a positive decimal"),
+    ("PT01:-2:03", "unable to parse '-2' as a positive number"),
+    ("P000000.1", "unable to parse '.1' as a positive number"),
     ("PT000000--", "unable to parse '000000--' into time components"),
     ("PT00:00:00,-", "unable to parse '00:00:00,-' into time components"),
     ("P-999Y", "unexpected character '-'"),


### PR DESCRIPTION
Some further exploration of ideas; again, as with #1, potentially-improved-readability here seems to be balanced against performance costs.

Both the introduction of dataclasses and the subsequent introduction of enumeration types each introduced performance penalties.

Tests should pass throughout the commit history, if I followed my own general engineering guidelines correctly - and that may help if you'd like to inspect the change-in-runtime with each adjustment, to identify how runtime performance changes with each commit.